### PR TITLE
HB-6489: temporary fix for CocoaPods

### DIFF
--- a/swift/Podfile
+++ b/swift/Podfile
@@ -24,3 +24,17 @@ target 'ChartboostMediationDemo' do
 #  pod 'ChartboostMediationAdapterYahoo'
 
 end
+
+# Temporary CocoaPods fix for Xcode 15. CocoaPods merged the fix already, but haven't
+# released it yet: https://github.com/CocoaPods/CocoaPods/pull/12009
+# See discussion here: https://github.com/CocoaPods/CocoaPods/issues/12012
+post_install do |installer|
+    installer.pods_project.targets.each do |target|
+        target.build_configurations.each do |config|
+            xcconfig_path = config.base_configuration_reference.real_path
+            xcconfig = File.read(xcconfig_path)
+            xcconfig_mod = xcconfig.gsub(/DT_TOOLCHAIN_DIR/, "TOOLCHAIN_DIR")
+            File.open(xcconfig_path, "w") { |file| file << xcconfig_mod }
+        end
+    end
+end

--- a/swiftui/Podfile
+++ b/swiftui/Podfile
@@ -24,3 +24,17 @@ target 'ChartboostMediationDemo' do
 #  pod 'ChartboostMediationAdapterYahoo'
 
 end
+
+# Temporary CocoaPods fix for Xcode 15. CocoaPods merged the fix already, but haven't
+# released it yet: https://github.com/CocoaPods/CocoaPods/pull/12009
+# See discussion here: https://github.com/CocoaPods/CocoaPods/issues/12012
+post_install do |installer|
+    installer.pods_project.targets.each do |target|
+        target.build_configurations.each do |config|
+            xcconfig_path = config.base_configuration_reference.real_path
+            xcconfig = File.read(xcconfig_path)
+            xcconfig_mod = xcconfig.gsub(/DT_TOOLCHAIN_DIR/, "TOOLCHAIN_DIR")
+            File.open(xcconfig_path, "w") { |file| file << xcconfig_mod }
+        end
+    end
+end


### PR DESCRIPTION
Tested this fix locally and on `mac-intel-1` by `pod install` + build app with and without this fix.

Temporary CocoaPods fix for Xcode 15. CocoaPods merged the fix already, but haven't released it yet: https://github.com/CocoaPods/CocoaPods/pull/12009

See discussion here: https://github.com/CocoaPods/CocoaPods/issues/12012

Corresponding main repo PR: https://github.com/ChartBoost/ios-helium-sdk/pull/1407