### PR TITLE
Use FullscreenAd API

### DIFF
--- a/swift/ChartboostMediationDemo.xcodeproj/project.pbxproj
+++ b/swift/ChartboostMediationDemo.xcodeproj/project.pbxproj
@@ -31,6 +31,10 @@
 		11D6027A1EC13FDB0075AF5E /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11D602791EC13FDB0075AF5E /* WebKit.framework */; };
 		11E67ECC203778E8004291DF /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 11E67ECB203778E8004291DF /* Launch Screen.storyboard */; };
 		250C89C367DF52B9DB4369AF /* Pods_ChartboostMediationDemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7AE515A97D15A95F1557BE54 /* Pods_ChartboostMediationDemo.framework */; };
+		9A100C0B2AC0F67300A7E6E1 /* Fullscreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9A100C0A2AC0F67300A7E6E1 /* Fullscreen.storyboard */; };
+		9A100C0D2AC0F69E00A7E6E1 /* FullscreenAdController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A100C0C2AC0F69E00A7E6E1 /* FullscreenAdController.swift */; };
+		9A100C0F2AC0F6C900A7E6E1 /* FullscreenAdViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A100C0E2AC0F6C900A7E6E1 /* FullscreenAdViewController.swift */; };
+		9AC709182AC2060E00406EF6 /* AdType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AC709172AC2060E00406EF6 /* AdType.swift */; };
 		B57E85E51A1FD5C400E6D9AD /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B57E85E41A1FD5C400E6D9AD /* AdSupport.framework */; };
 		DA93B6B1182B31BC00C21472 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA93B6B0182B31BC00C21472 /* Foundation.framework */; };
 		DA93B6B3182B31BC00C21472 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA93B6B2182B31BC00C21472 /* CoreGraphics.framework */; };
@@ -86,6 +90,10 @@
 		11E67ECB203778E8004291DF /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
 		7AE515A97D15A95F1557BE54 /* Pods_ChartboostMediationDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ChartboostMediationDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		812758213C6048C552CE5416 /* Pods-ChartboostMediationDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ChartboostMediationDemo.debug.xcconfig"; path = "Target Support Files/Pods-ChartboostMediationDemo/Pods-ChartboostMediationDemo.debug.xcconfig"; sourceTree = "<group>"; };
+		9A100C0A2AC0F67300A7E6E1 /* Fullscreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Fullscreen.storyboard; path = ChartboostMediationDemo/Ads/Fullscreen/Fullscreen.storyboard; sourceTree = SOURCE_ROOT; };
+		9A100C0C2AC0F69E00A7E6E1 /* FullscreenAdController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FullscreenAdController.swift; path = ChartboostMediationDemo/Ads/Fullscreen/FullscreenAdController.swift; sourceTree = SOURCE_ROOT; };
+		9A100C0E2AC0F6C900A7E6E1 /* FullscreenAdViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FullscreenAdViewController.swift; path = ChartboostMediationDemo/Ads/Fullscreen/FullscreenAdViewController.swift; sourceTree = SOURCE_ROOT; };
+		9AC709172AC2060E00406EF6 /* AdType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdType.swift; sourceTree = "<group>"; };
 		9EE694D13617DA6474AC6767 /* Pods-ChartboostMediationDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ChartboostMediationDemo.release.xcconfig"; path = "Target Support Files/Pods-ChartboostMediationDemo/Pods-ChartboostMediationDemo.release.xcconfig"; sourceTree = "<group>"; };
 		B57E85E41A1FD5C400E6D9AD /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
 		DA93B6AD182B31BC00C21472 /* ChartboostMediationDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChartboostMediationDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -174,6 +182,16 @@
 			path = Pods;
 			sourceTree = "<group>";
 		};
+		9A100C092AC0F61A00A7E6E1 /* Fullscreen */ = {
+			isa = PBXGroup;
+			children = (
+				9A100C0A2AC0F67300A7E6E1 /* Fullscreen.storyboard */,
+				9A100C0C2AC0F69E00A7E6E1 /* FullscreenAdController.swift */,
+				9A100C0E2AC0F6C900A7E6E1 /* FullscreenAdViewController.swift */,
+			);
+			path = Fullscreen;
+			sourceTree = "<group>";
+		};
 		DA93B6A4182B31BC00C21472 = {
 			isa = PBXGroup;
 			children = (
@@ -258,8 +276,10 @@
 				E695ACFB28B57AC5000160CE /* ChartboostMediationController.swift */,
 				E695ACF328B569C3000160CE /* AdTypeSelectionViewController.swift */,
 				E695ACEE28B53561000160CE /* Banner */,
+				9A100C092AC0F61A00A7E6E1 /* Fullscreen */,
 				E695ACEC28B53556000160CE /* Interstitial */,
 				E695ACED28B5355B000160CE /* Rewarded */,
+				9AC709172AC2060E00406EF6 /* AdType.swift */,
 			);
 			path = Ads;
 			sourceTree = "<group>";
@@ -368,6 +388,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9A100C0B2AC0F67300A7E6E1 /* Fullscreen.storyboard in Resources */,
 				E695AD0528B58A36000160CE /* Busy.storyboard in Resources */,
 				11E67ECC203778E8004291DF /* Launch Screen.storyboard in Resources */,
 				DA93B6BB182B31BC00C21472 /* InfoPlist.strings in Resources */,
@@ -429,8 +450,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				E695AD0728B58C1C000160CE /* Alert.swift in Sources */,
+				9A100C0F2AC0F6C900A7E6E1 /* FullscreenAdViewController.swift in Sources */,
 				E66016E728B67A8700ABE0B7 /* Collection+Extras.swift in Sources */,
 				E695AD1328B59323000160CE /* BannerAdViewController.swift in Sources */,
+				9A100C0D2AC0F69E00A7E6E1 /* FullscreenAdController.swift in Sources */,
 				E695AD0D28B58FAA000160CE /* RewardedAdViewController.swift in Sources */,
 				E695ACF628B56F88000160CE /* Colors.swift in Sources */,
 				E695ACFC28B57AC5000160CE /* ChartboostMediationController.swift in Sources */,
@@ -438,6 +461,7 @@
 				E695ACFA28B57A8C000160CE /* InterstitialAdViewController.swift in Sources */,
 				E62D990828B52CFE0035F1D2 /* AppDelegate.swift in Sources */,
 				E695AD0328B58A2E000160CE /* Busy.swift in Sources */,
+				9AC709182AC2060E00406EF6 /* AdType.swift in Sources */,
 				E695AD0028B588BE000160CE /* ActivityDelegate.swift in Sources */,
 				E695AD1228B59323000160CE /* BannerAdController.swift in Sources */,
 				E695ACE628B532BC000160CE /* InterstitialAdController.swift in Sources */,

--- a/swift/ChartboostMediationDemo/Ads/AdType.swift
+++ b/swift/ChartboostMediationDemo/Ads/AdType.swift
@@ -1,0 +1,24 @@
+//
+//  AdType.swift
+//  ChartboostMediationDemo
+//
+//  Created by Alexander Rice on 9/25/23.
+//  Copyright © 2023 Chartboost. All rights reserved.
+//
+
+import UIKit
+
+/// An enumeration of each advertisement type.
+enum AdType: String, CaseIterable {
+    case banner
+    case interstitial
+    case rewarded
+
+    var title: String {
+        rawValue.capitalized
+    }
+
+    var icon: UIImage? {
+        UIImage(named: title)
+    }
+}

--- a/swift/ChartboostMediationDemo/Ads/AdTypeSelectionViewController.swift
+++ b/swift/ChartboostMediationDemo/Ads/AdTypeSelectionViewController.swift
@@ -105,12 +105,7 @@ extension AdTypeSelectionViewController: UITableViewDelegate {
         // The cast in adView(forAdType:) should always succeed, but since we have to unwrap the
         // optional at some point we might as well catch it if there's a problem.
         guard let viewController = adView(forAdType: adType) else {
-            // Alert the user that we can't proceed
-            let alert = UIAlertController(title: "Error",
-                                          message: "Could not create view for ",
-                                          preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-            self.present(alert, animated: true, completion: nil)
+            assertionFailure("Could not create view for Ad")
             return
         }
         navigationController?.pushViewController(viewController, animated: true)

--- a/swift/ChartboostMediationDemo/Ads/AdTypeSelectionViewController.swift
+++ b/swift/ChartboostMediationDemo/Ads/AdTypeSelectionViewController.swift
@@ -33,14 +33,7 @@ import UIKit
 class AdTypeSelectionViewController: UIViewController {
 
     @IBOutlet private var tableView: UITableView!
-
-    /// Current state of the "Use Fullscreen API" switch
-    var useFullscreenAPI: Bool = false
-
     @IBOutlet var apiToggle: UISwitch!
-    @IBAction func apiValueChanged(_ sender: UISwitch) {
-        useFullscreenAPI = sender.isOn
-    }
 
     // MARK: - Lifecycle
 
@@ -55,8 +48,6 @@ class AdTypeSelectionViewController: UIViewController {
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: "AdTypeSelectionCell")
         tableView.separatorColor = .chartboost
         navigationController?.setNavigationBarHidden(true, animated: false)
-        // Make sure useFullscreenAPI and the switch are in the same state
-        useFullscreenAPI = apiToggle?.isOn ?? false
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -71,7 +62,7 @@ class AdTypeSelectionViewController: UIViewController {
 
     func adView(forAdType adType: AdType) -> UIViewController? {
         let title = adType.title
-        if useFullscreenAPI {
+        if apiToggle.isOn {
             // If we're using the fullscreen API, we need to set the ad type for Rewarded & Interstitial
             switch adType {
             case .banner:

--- a/swift/ChartboostMediationDemo/Ads/AdTypeSelectionViewController.swift
+++ b/swift/ChartboostMediationDemo/Ads/AdTypeSelectionViewController.swift
@@ -32,6 +32,7 @@ import UIKit
 /// 
 class AdTypeSelectionViewController: UIViewController {
 
+    @IBOutlet private var useFullscreenToggle: UISwitch!
     @IBOutlet private var tableView: UITableView!
 
     /// An enumeration of each advertisement type.

--- a/swift/ChartboostMediationDemo/Ads/AdTypeSelectionViewController.swift
+++ b/swift/ChartboostMediationDemo/Ads/AdTypeSelectionViewController.swift
@@ -93,17 +93,3 @@ extension AdTypeSelectionViewController: UITableViewDataSource {
         return cell
     }
 }
-
-extension AdTypeSelectionViewController.AdType {
-    var title: String {
-        rawValue.capitalized
-    }
-
-    var icon: UIImage? {
-        UIImage(named: title)
-    }
-
-    var viewController: UIViewController {
-        UIStoryboard(name: title, bundle: nil).instantiateViewController(withIdentifier: title)
-    }
-}

--- a/swift/ChartboostMediationDemo/Ads/Fullscreen/Fullscreen.storyboard
+++ b/swift/ChartboostMediationDemo/Ads/Fullscreen/Fullscreen.storyboard
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Fullscreen-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="Fullscreen" title="Fullscreen" id="Y6W-OH-hqX" customClass="FullscreenAdViewController" customModule="ChartboostMediationDemo" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="7lM-BA-fgY">
+                                <rect key="frame" x="32" y="100" width="350" height="454"/>
+                                <subviews>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Interstitial" translatesAutoresizingMaskIntoConstraints="NO" id="6je-P3-iv5">
+                                        <rect key="frame" x="0.0" y="0.0" width="350" height="86"/>
+                                    </imageView>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="e0K-YL-MtS" userLabel="spacer">
+                                        <rect key="frame" x="0.0" y="102" width="350" height="16"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="16" id="TG6-un-oDP"/>
+                                        </constraints>
+                                    </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="A full screen interstitial advertisement must first be loaded." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9xX-pc-VAc">
+                                        <rect key="frame" x="0.0" y="134" width="350" height="42.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Eid-VV-iRP">
+                                        <rect key="frame" x="0.0" y="192.5" width="350" height="64"/>
+                                        <color key="backgroundColor" red="0.4823529412" green="0.74509803919999995" blue="0.21960784310000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="64" id="LAX-ss-evP"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                        <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                        <state key="normal" title="Load"/>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                <integer key="value" value="12"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <action selector="loadButtonPushed" destination="Y6W-OH-hqX" eventType="touchUpInside" id="Y1C-Da-Oba"/>
+                                        </connections>
+                                    </button>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="arrow-down" translatesAutoresizingMaskIntoConstraints="NO" id="7L9-gM-dVk">
+                                        <rect key="frame" x="0.0" y="272.5" width="350" height="43"/>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="After it has been successfully loaded it can then be shown." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vYz-6q-qvZ">
+                                        <rect key="frame" x="0.0" y="331.5" width="350" height="42.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BJN-QZ-zsJ">
+                                        <rect key="frame" x="0.0" y="390" width="350" height="64"/>
+                                        <color key="backgroundColor" red="0.4823529412" green="0.74509803919999995" blue="0.21960784310000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="64" id="YOl-iO-B3C"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                        <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                        <state key="normal" title="Show"/>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                <integer key="value" value="12"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <action selector="showButtonPushed" destination="Y6W-OH-hqX" eventType="touchUpInside" id="j4C-Ow-UNE"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="7lM-BA-fgY" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="32" id="CZp-Dx-FLf"/>
+                            <constraint firstItem="7lM-BA-fgY" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="8" id="FYP-pb-4bN"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="7lM-BA-fgY" secondAttribute="trailing" constant="32" id="eZz-mB-GxU"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" title="[placeholder text]" id="aRV-nI-4Qs"/>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="139" y="138"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="Interstitial" width="86" height="86"/>
+        <image name="arrow-down" width="43" height="43"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/swift/ChartboostMediationDemo/Ads/Fullscreen/FullscreenAdController.swift
+++ b/swift/ChartboostMediationDemo/Ads/Fullscreen/FullscreenAdController.swift
@@ -95,7 +95,7 @@ class FullscreenAdController: NSObject {
             return
         }
 
-        // ChartboostMediationFullscreenAd does not have an equivalent to HeliumInterstitialAd's readyToShow().
+        // Once you've loaded a ChartboostMediationFullscreenAd, it can be shown immediately.
 
         // Notify the demo UI.
         activityDelegate?.activityDidStart()

--- a/swift/ChartboostMediationDemo/Ads/Fullscreen/FullscreenAdController.swift
+++ b/swift/ChartboostMediationDemo/Ads/Fullscreen/FullscreenAdController.swift
@@ -78,10 +78,8 @@ class FullscreenAdController: NSObject {
                 fullscreenAd = nil
                 self.log(action: "Load error", placementName: placementName, error: result.error)
 
-                // `.failed` requires a non-optional error type
-                let error = result.error ?? NSError(domain: "com.chartboost.mediation.demo", code: 0)
                 // Notify the demo UI
-                activityDelegate?.activityDidEnd(message: "Failed to load the advertisement.", error: error)
+                activityDelegate?.activityDidEnd(message: "Failed to load the advertisement.", error: nil)
             }
         }
     }

--- a/swift/ChartboostMediationDemo/Ads/Fullscreen/FullscreenAdController.swift
+++ b/swift/ChartboostMediationDemo/Ads/Fullscreen/FullscreenAdController.swift
@@ -44,7 +44,7 @@ class FullscreenAdController: NSObject {
             placementName = "AllNetworkInterstitial"
         case .rewarded:
             placementName = "AllNetworkRewarded"
-        // If adType is nill or not a fullscreen type, give an empty placement name that won't load
+        // If adType is nil or not a fullscreen type, give an empty placement name that won't load
         default:
             placementName = ""
         }
@@ -52,7 +52,7 @@ class FullscreenAdController: NSObject {
 
     /// Load the fullscreen ad.
     /// - Parameter keywords: Optional keywords that can be associated with the advertisement placement.
-    func load(keywords: HeliumKeywords? = nil) {
+    func load() {
         // Attempt to load the ad only if it has not already been created and requested to load.
         guard fullscreenAd == nil else {
             print("[Warning] fullscreen advertisement has already been loaded")
@@ -62,9 +62,7 @@ class FullscreenAdController: NSObject {
         // Notify the demo UI
         activityDelegate?.activityDidStart()
 
-        // loadFullscreenAd expects keywords to be `[String : String]` instead of `HeliumKeywords?`.
-        let keywords = keywords?.dictionary ?? [:]
-        let request = ChartboostMediationAdLoadRequest(placement: placementName, keywords: keywords)
+        let request = ChartboostMediationAdLoadRequest(placement: placementName, keywords: [:])
         // Load the fullscreen ad, which will make a request to the network. Upon completion, a
         // ChartboostMediationFullscreenAdLoadResult will be passed to the completion block.
         chartboostMediation.loadFullscreenAd(with: request) { [weak self] result in

--- a/swift/ChartboostMediationDemo/Ads/Fullscreen/FullscreenAdController.swift
+++ b/swift/ChartboostMediationDemo/Ads/Fullscreen/FullscreenAdController.swift
@@ -100,8 +100,7 @@ class FullscreenAdController: NSObject {
         // Notify the demo UI.
         activityDelegate?.activityDidStart()
 
-        // Show the ad using the specified view controller.  Upon completion, instead of using a delegate
-        // method a ChartboostMediationAdShowResult will be passed to the completion block.
+        // Show the ad using the specified view controller.  Upon completion, a ChartboostMediationAdShowResult will be passed to the completion block.
         fullscreenAd.show(with: viewController, completion: { [weak self] result in
             guard let self = self else { return }
             self.log(action: "show", placementName: self.placementName, error: result.error)

--- a/swift/ChartboostMediationDemo/Ads/Fullscreen/FullscreenAdController.swift
+++ b/swift/ChartboostMediationDemo/Ads/Fullscreen/FullscreenAdController.swift
@@ -1,0 +1,171 @@
+// Copyright 2022-2023 Chartboost, Inc.
+// 
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+//
+//  FullscreenAdController.swift
+//  ChartboostMediationDemo
+//
+//  Copyright © 2023 Chartboost. All rights reserved.
+//
+
+import UIKit
+import ChartboostMediationSDK
+
+/// A basic implementation of a controller for Chartboost Mediation fullscreen ads.  It is capable of loading and showing a full screen fullscreen ad
+/// for a single placement.  This controller is also its own `CHBHeliumFullscreenAdDelegate` so that it is in full control
+/// of the ad's lifecycle.
+class FullscreenAdController: NSObject {
+    /// The entry point for the Chartboost Mediation SDK.
+    private let chartboostMediation = Helium.shared()
+
+    /// Which type of fullscreen ad is managed by this controller
+    private let adType: AdType?
+
+    /// The placement that is controller is for.
+    private var placementName: String
+
+    /// An instance of the fullscreen ad that this class controls the lifecycle of.
+    private var fullscreenAd: ChartboostMediationFullscreenAd?
+
+    /// A delegate for demo purposes only so that long activity processes can be communicated to a view controller.
+    private weak var activityDelegate: ActivityDelegate?
+
+    /// Initializer for the view model.
+    /// - Parameter placementName: Placement to use.
+    /// - Parameter activityDelegate: A delegate to communicate the start and end of asyncronous activity to.  This is applicable only for this demo.
+    init(adType: AdType?, activityDelegate: ActivityDelegate) {
+        self.adType = adType
+        self.activityDelegate = activityDelegate
+
+        switch adType {
+        case .interstitial:
+            placementName = "AllNetworkInterstitial"
+        case .rewarded:
+            placementName = "AllNetworkRewarded"
+        // If adType is nill or not a fullscreen type, give an empty placement name that won't load
+        default:
+            placementName = ""
+        }
+    }
+
+    /// Load the fullscreen ad.
+    /// - Parameter keywords: Optional keywords that can be associated with the advertisement placement.
+    func load(keywords: HeliumKeywords? = nil) {
+        // Attempt to load the ad only if it has not already been created and requested to load.
+        guard fullscreenAd == nil else {
+            print("[Warning] fullscreen advertisement has already been loaded")
+            return
+        }
+
+        // Notify the demo UI
+        activityDelegate?.activityDidStart()
+
+        // loadFullscreenAd expects keywords to be `[String : String]` instead of `HeliumKeywords?`.
+        let keywords = keywords?.dictionary ?? [:]
+        let request = ChartboostMediationAdLoadRequest(placement: placementName, keywords: keywords)
+        // Load the fullscreen ad, which will make a request to the network. Upon completion, a
+        // ChartboostMediationFullscreenAdLoadResult will be passed to the completion block.
+        chartboostMediation.loadFullscreenAd(with: request) { [weak self] result in
+            guard let self = self else { return }
+            if let ad = result.ad {
+                ad.delegate = self
+                self.fullscreenAd = ad
+
+                log(action: "load", placementName: placementName, error: result.error)
+                // Notify the demo UI
+                activityDelegate?.activityDidEnd()
+            } else {
+                fullscreenAd = nil
+                self.log(action: "Load error", placementName: placementName, error: result.error)
+
+                // `.failed` requires a non-optional error type
+                let error = result.error ?? NSError(domain: "com.chartboost.mediation.demo", code: 0)
+                // Notify the demo UI
+                activityDelegate?.activityDidEnd(message: "Failed to load the advertisement.", error: error)
+            }
+        }
+    }
+
+    /// Show the fullscreen ad if it has been loaded and is ready to show.
+    /// - Parameter viewController: The view controller to present the fullscreen over.
+    func show(with viewController: UIViewController) {
+        // Attempt to show an ad only if it has been loaded.
+        guard let fullscreenAd = fullscreenAd else {
+            print("[Error] cannot show an fullscreen advertisement that has not yet been loaded")
+            return
+        }
+
+        // ChartboostMediationFullscreenAd does not have an equivalent to HeliumInterstitialAd's readyToShow().
+
+        // Notify the demo UI.
+        activityDelegate?.activityDidStart()
+
+        // Show the ad using the specified view controller.  Upon completion, instead of using a delegate
+        // method a ChartboostMediationAdShowResult will be passed to the completion block.
+        fullscreenAd.show(with: viewController, completion: { [weak self] result in
+            guard let self = self else { return }
+            self.log(action: "show", placementName: self.placementName, error: result.error)
+
+            // For simplicity, an ad that has failed to show will be destroyed.
+            if let error = result.error {
+                self.fullscreenAd = nil
+
+                // Notify the demo UI
+                activityDelegate?.activityDidEnd(message: "Failed to load the advertisement.", error: error)
+            }
+            else {
+                // Notify the demo UI
+                activityDelegate?.activityDidEnd()
+            }
+        })
+    }
+}
+
+// MARK: - Lifecycle Delegate
+
+/// Implementation of the Chartboost Mediation fullscreen ad delegate.
+extension FullscreenAdController: ChartboostMediationFullscreenAdDelegate {
+    func didRecordImpression(ad: ChartboostMediationFullscreenAd) {
+        log(action: "Did record impression", placementName: placementName, error: nil)
+    }
+
+    func didClick(ad: ChartboostMediationFullscreenAd) {
+        log(action: "Did click", placementName: placementName, error: nil)
+    }
+
+    func didReward(ad: ChartboostMediationFullscreenAd) {
+        log(action: "Did get reward", placementName: placementName, error: nil)
+    }
+
+    func didClose(ad: ChartboostMediationFullscreenAd, error: ChartboostMediationError?) {
+        if let error = error {
+            log(action: "Close error", placementName: placementName, error: error)
+        }
+        else {
+            log(action: "Did close", placementName: placementName, error: nil)
+        }
+    }
+
+    func didExpire(ad: ChartboostMediationFullscreenAd) {
+        log(action: "Did expire", placementName: placementName, error: nil)
+    }
+}
+
+// MARK: - Utility
+
+private extension FullscreenAdController {
+    /// Log lifecycle information to the console for the fullscreen advertisement.
+    /// - Parameter action: What action is being logged
+    /// - Parameter placementName: The placement name for the fullscreen advertisement
+    /// - Parameter error: An option error that occurred
+    func log(action: String, placementName: String, error: ChartboostMediationError?) {
+        if let error = error {
+            print("[Error] did \(action) fullscreen advertisement for placement '\(placementName)': '\(error.debugDescription)' (name: \(error.chartboostMediationCode.name), code: \(error.code))")
+        }
+        else {
+            print("[Success] did \(action) fullscreen advertisement for placement '\(placementName)'")
+        }
+    }
+}

--- a/swift/ChartboostMediationDemo/Ads/Fullscreen/FullscreenAdViewController.swift
+++ b/swift/ChartboostMediationDemo/Ads/Fullscreen/FullscreenAdViewController.swift
@@ -1,0 +1,42 @@
+// Copyright 2022-2023 Chartboost, Inc.
+// 
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+//
+//  FullscreenAdViewController.swift
+//  ChartboostMediationDemo
+//
+//  Copyright © 2023 Chartboost. All rights reserved.
+//
+
+import UIKit
+
+/// An example view controller that can load and show a full screen advertisement on the screen.
+///
+/// Take a look at `FullscreenAdController` for details on how to load and show a fullscreen advertisement.
+///
+class FullscreenAdViewController: UIViewController {
+
+    /// Both interstitial and rewarded ads use the FullscreenAd API.
+    /// If adType is not set to one of these before self.controller is accessed, no ad will load
+    var adType: AdType?
+
+    /// An instance of the `FullscreenAdController` that is configured to use the placement "AllNetworkFullscreen"
+    lazy var controller = FullscreenAdController(adType: self.adType, activityDelegate: self)
+
+    /// The handler for when the load button is pushed.  Pushing it results in the insterstitial ad being loaded.
+    /// After it has successfully loaded, it can then be shown.
+    @IBAction func loadButtonPushed() {
+        controller.load()
+    }
+
+    /// The handler for when the show button is pushed.  Pushing it results in the fullscreen ad being shown if it was successfully loaded.
+    @IBAction func showButtonPushed() {
+        controller.show(with: self)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        title = adType?.title ?? "Fullscreen Ad"
+    }
+}

--- a/swift/ChartboostMediationDemo/Ads/Main.storyboard
+++ b/swift/ChartboostMediationDemo/Ads/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="1Bj-a4-AkX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="1Bj-a4-AkX">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -113,9 +113,6 @@
                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" title="Use Fullscreen API" translatesAutoresizingMaskIntoConstraints="NO" id="4KD-8X-JIf">
                                                 <rect key="frame" x="328" y="7.9999999999999982" width="51" height="20.333333333333329"/>
                                                 <color key="onTintColor" name="Accent"/>
-                                                <connections>
-                                                    <action selector="apiValueChanged:" destination="oek-vc-sYl" eventType="valueChanged" id="4rQ-mH-bSH"/>
-                                                </connections>
                                             </switch>
                                         </subviews>
                                         <directionalEdgeInsets key="directionalLayoutMargins" top="8" leading="16" bottom="8" trailing="16"/>

--- a/swift/ChartboostMediationDemo/Ads/Main.storyboard
+++ b/swift/ChartboostMediationDemo/Ads/Main.storyboard
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="1Bj-a4-AkX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="1Bj-a4-AkX">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -21,14 +22,14 @@
                                 <rect key="frame" x="0.0" y="103" width="393" height="715"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Logo" translatesAutoresizingMaskIntoConstraints="NO" id="0l0-Cl-DAb">
-                                        <rect key="frame" x="68.666666666666671" y="260.33333333333331" width="255.66666666666669" height="66.666666666666686"/>
+                                        <rect key="frame" x="68.666666666666671" y="193.66666666666669" width="255.66666666666663" height="200"/>
                                     </imageView>
                                     <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" animating="YES" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="Bc9-BC-nWH">
-                                        <rect key="frame" x="186.66666666666666" y="345" width="20" height="20"/>
+                                        <rect key="frame" x="186.66666666666666" y="411.66666666666663" width="20" height="20"/>
                                         <color key="color" red="0.4823529412" green="0.74509803919999995" blue="0.21960784310000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </activityIndicatorView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Initializing the Helium SDK..." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Eng-7D-APF">
-                                        <rect key="frame" x="32" y="385" width="329" height="20.333333333333314"/>
+                                        <rect key="frame" x="32" y="451.66666666666663" width="329" height="20.333333333333314"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -100,8 +101,24 @@
                                             <constraint firstAttribute="height" constant="64" id="0zi-GD-mKg"/>
                                         </constraints>
                                     </imageView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XtY-aE-2iB">
+                                        <rect key="frame" x="0.0" y="96" width="393" height="36.333333333333343"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Use Fullscreen API" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TTa-qC-YuQ">
+                                                <rect key="frame" x="16" y="7.9999999999999982" width="312" height="20.333333333333329"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" title="Use Fullscreen API" translatesAutoresizingMaskIntoConstraints="NO" id="4KD-8X-JIf">
+                                                <rect key="frame" x="328" y="7.9999999999999982" width="51" height="20.333333333333329"/>
+                                                <color key="onTintColor" name="Accent"/>
+                                            </switch>
+                                        </subviews>
+                                        <directionalEdgeInsets key="directionalLayoutMargins" top="8" leading="16" bottom="8" trailing="16"/>
+                                    </stackView>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="120" estimatedRowHeight="120" sectionHeaderHeight="28" estimatedSectionHeaderHeight="28" sectionFooterHeight="28" estimatedSectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="sR3-CA-tj4">
-                                        <rect key="frame" x="0.0" y="96" width="393" height="647"/>
+                                        <rect key="frame" x="0.0" y="164.33333333333331" width="393" height="578.66666666666674"/>
                                         <connections>
                                             <outlet property="dataSource" destination="oek-vc-sYl" id="e2G-sf-Nlm"/>
                                             <outlet property="delegate" destination="oek-vc-sYl" id="Z0D-Su-PMW"/>
@@ -122,6 +139,7 @@
                     <navigationItem key="navigationItem" largeTitleDisplayMode="never" id="232-W3-tTv"/>
                     <connections>
                         <outlet property="tableView" destination="sR3-CA-tj4" id="mQf-aL-qR3"/>
+                        <outlet property="useFullscreenToggle" destination="4KD-8X-JIf" id="xzH-6D-GJg"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="CW5-p0-12I" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -130,7 +148,10 @@
         </scene>
     </scenes>
     <resources>
-        <image name="Logo" width="240.66667175292969" height="66.666664123535156"/>
+        <image name="Logo" width="722" height="200"/>
+        <namedColor name="Accent">
+            <color red="0.4823529411764706" green="0.74509803921568629" blue="0.2196078431372549" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/swift/ChartboostMediationDemo/Ads/Main.storyboard
+++ b/swift/ChartboostMediationDemo/Ads/Main.storyboard
@@ -110,9 +110,12 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" title="Use Fullscreen API" translatesAutoresizingMaskIntoConstraints="NO" id="4KD-8X-JIf">
+                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" title="Use Fullscreen API" translatesAutoresizingMaskIntoConstraints="NO" id="4KD-8X-JIf">
                                                 <rect key="frame" x="328" y="7.9999999999999982" width="51" height="20.333333333333329"/>
                                                 <color key="onTintColor" name="Accent"/>
+                                                <connections>
+                                                    <action selector="apiValueChanged:" destination="oek-vc-sYl" eventType="valueChanged" id="4rQ-mH-bSH"/>
+                                                </connections>
                                             </switch>
                                         </subviews>
                                         <directionalEdgeInsets key="directionalLayoutMargins" top="8" leading="16" bottom="8" trailing="16"/>
@@ -138,8 +141,8 @@
                     </view>
                     <navigationItem key="navigationItem" largeTitleDisplayMode="never" id="232-W3-tTv"/>
                     <connections>
+                        <outlet property="apiToggle" destination="4KD-8X-JIf" id="08d-Lk-WRz"/>
                         <outlet property="tableView" destination="sR3-CA-tj4" id="mQf-aL-qR3"/>
-                        <outlet property="useFullscreenToggle" destination="4KD-8X-JIf" id="xzH-6D-GJg"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="CW5-p0-12I" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/swift/ChartboostMediationDemo/Utility/ActivityDelegate.swift
+++ b/swift/ChartboostMediationDemo/Utility/ActivityDelegate.swift
@@ -14,5 +14,5 @@
 protocol ActivityDelegate: AnyObject {
     func activityDidStart()
     func activityDidEnd()
-    func activityDidEnd(message: String, error: Error)
+    func activityDidEnd(message: String, error: Error?)
 }

--- a/swift/ChartboostMediationDemo/Utility/Alert.swift
+++ b/swift/ChartboostMediationDemo/Utility/Alert.swift
@@ -15,13 +15,13 @@ import ChartboostMediationSDK
 
 /// An extenstion that is relevant for this demo only. It is not applicable to anything specific to the Chartboost Mediation SDK.
 extension UIViewController {
-    func presentAlert(message: String, error: Error) {
+    func presentAlert(message: String, error: Error?) {
         let alertMessage: String
         if let chartboostMediationError = error as? ChartboostMediationError {
             alertMessage = "\(message)\n\n\(chartboostMediationError.localizedFailureReason ?? "Reason unspecified.")\n\n\(chartboostMediationError.chartboostMediationCode.name)"
         }
         else {
-            alertMessage = "\(message)\n\n\(error)"
+            alertMessage = "\(message)\n\n\(String(describing: error))"
         }
         let alert = UIAlertController(title: "Error", message: alertMessage, preferredStyle: .alert)
         alert.addAction(.init(title: "OK", style: .default))

--- a/swift/ChartboostMediationDemo/Utility/Busy.swift
+++ b/swift/ChartboostMediationDemo/Utility/Busy.swift
@@ -46,7 +46,7 @@ extension UIViewController: ActivityDelegate {
         })
     }
 
-    func activityDidEnd(message: String, error: Error) {
+    func activityDidEnd(message: String, error: Error?) {
         if let busy = busy {
             busy.dismiss(animated: true, completion: {
                 self.busy = nil

--- a/swiftui/ChartboostMediationDemo.xcodeproj/project.pbxproj
+++ b/swiftui/ChartboostMediationDemo.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 
 /* Begin PBXFileReference section */
 		191C655036FEA5200B0F9B9F /* Pods-ChartboostMediationDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ChartboostMediationDemo.release.xcconfig"; path = "Target Support Files/Pods-ChartboostMediationDemo/Pods-ChartboostMediationDemo.release.xcconfig"; sourceTree = "<group>"; };
+		9AB7AD6A2ABBB4A50036B3EB /* FullscreenAdController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullscreenAdController.swift; sourceTree = "<group>"; };
+		9AB7AD6B2ABBB4C90036B3EB /* FullscreenAdView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullscreenAdView.swift; sourceTree = "<group>"; };
 		AD4BA50B0885969AB837FF29 /* Pods_ChartboostMediationDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ChartboostMediationDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E66C9FF62A24EA9000315DC4 /* ChartboostMediationDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChartboostMediationDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E66C9FF92A24EA9000315DC4 /* ChartboostMediationDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartboostMediationDemoApp.swift; sourceTree = "<group>"; };
@@ -75,6 +77,15 @@
 				AD4BA50B0885969AB837FF29 /* Pods_ChartboostMediationDemo.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		9AB7AD692ABBB48A0036B3EB /* Fullscreen */ = {
+			isa = PBXGroup;
+			children = (
+				9AB7AD6A2ABBB4A50036B3EB /* FullscreenAdController.swift */,
+				9AB7AD6B2ABBB4C90036B3EB /* FullscreenAdView.swift */,
+			);
+			path = Fullscreen;
 			sourceTree = "<group>";
 		};
 		BA1D0EBA659F7F5F9891F16F /* Pods */ = {
@@ -134,6 +145,7 @@
 				E66CA00E2A24ECC200315DC4 /* ChartboostMediationController.swift */,
 				E66CA00C2A24EC6900315DC4 /* ChartboostMediationInititializationView.swift */,
 				E66CA0172A24FA0100315DC4 /* Banner */,
+				9AB7AD692ABBB48A0036B3EB /* Fullscreen */,
 				E66CA0182A24FA0E00315DC4 /* Interstitial */,
 				E66CA0192A24FA1700315DC4 /* Rewarded */,
 			);

--- a/swiftui/ChartboostMediationDemo.xcodeproj/project.pbxproj
+++ b/swiftui/ChartboostMediationDemo.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9A100C072ABCEBC300A7E6E1 /* FullscreenAdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AB7AD6B2ABBB4C90036B3EB /* FullscreenAdView.swift */; };
+		9A100C082ABCEBC300A7E6E1 /* FullscreenAdController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AB7AD6A2ABBB4A50036B3EB /* FullscreenAdController.swift */; };
 		9F2B0841095D4D40883BB4D0 /* Pods_ChartboostMediationDemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AD4BA50B0885969AB837FF29 /* Pods_ChartboostMediationDemo.framework */; };
 		E66C9FFA2A24EA9000315DC4 /* ChartboostMediationDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66C9FF92A24EA9000315DC4 /* ChartboostMediationDemoApp.swift */; };
 		E66C9FFE2A24EA9100315DC4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E66C9FFD2A24EA9100315DC4 /* Assets.xcassets */; };
@@ -324,6 +326,8 @@
 				E66CA0252A24FD1700315DC4 /* ActivityState.swift in Sources */,
 				E66CA0232A24FC8400315DC4 /* InterstitialAdController.swift in Sources */,
 				E66CA01F2A24FA6F00315DC4 /* RewardedAdView.swift in Sources */,
+				9A100C082ABCEBC300A7E6E1 /* FullscreenAdController.swift in Sources */,
+				9A100C072ABCEBC300A7E6E1 /* FullscreenAdView.swift in Sources */,
 				E686E8922A28FCAF0045BC43 /* Application+Extras.swift in Sources */,
 				E66CA00D2A24EC6900315DC4 /* ChartboostMediationInititializationView.swift in Sources */,
 				E66CA0212A24FACD00315DC4 /* AdType.swift in Sources */,

--- a/swiftui/ChartboostMediationDemo/Ads/AdTypeSelectionView.swift
+++ b/swiftui/ChartboostMediationDemo/Ads/AdTypeSelectionView.swift
@@ -58,15 +58,15 @@ struct AdTypeSelectionView: View {
                     Group {
                         switch (adType, useFullscreenApi) {
                         case (.banner, _):
-                            BannerAdView()
+                            BannerAdView(placementName: "AllNetworkBanner")
                         case (.interstitial, false):
-                            InterstitialAdView()
+                            InterstitialAdView(placementName: "AllNetworkInterstitial")
                         case (.interstitial, true):
-                            FullscreenAdView()
+                            FullscreenAdView(placementName: "AllNetworkInterstitial")
                         case (.rewarded, false):
-                            RewardedAdView()
+                            RewardedAdView(placementName: "AllNetworkRewarded")
                         case (.rewarded, true):
-                            FullscreenAdView()
+                            FullscreenAdView(placementName: "AllNetworkRewarded")
                         }
                     }
                     .frame(minHeight: geometry.size.height)

--- a/swiftui/ChartboostMediationDemo/Ads/AdTypeSelectionView.swift
+++ b/swiftui/ChartboostMediationDemo/Ads/AdTypeSelectionView.swift
@@ -61,11 +61,11 @@ struct AdTypeSelectionView: View {
                     case (.interstitial, false):
                         InterstitialAdView(placementName: "AllNetworkInterstitial")
                     case (.interstitial, true):
-                        FullscreenAdView(placementName: "AllNetworkInterstitial")
+                        FullscreenAdView(adType: adType, placementName: "AllNetworkInterstitial")
                     case (.rewarded, false):
                         RewardedAdView(placementName: "AllNetworkRewarded")
                     case (.rewarded, true):
-                        FullscreenAdView(placementName: "AllNetworkRewarded")
+                        FullscreenAdView(adType: adType, placementName: "AllNetworkRewarded")
                     }
                 }
                 .frame(minHeight: geometry.size.height)

--- a/swiftui/ChartboostMediationDemo/Ads/AdTypeSelectionView.swift
+++ b/swiftui/ChartboostMediationDemo/Ads/AdTypeSelectionView.swift
@@ -29,11 +29,9 @@ struct AdTypeSelectionView: View {
                             .padding(.vertical, 8)
                         Spacer()
                     }
-                    HStack {
-                        Toggle("Use Fullscreen API", isOn: $useFullscreenApi)
-                            .padding(.horizontal)
-                            .tint(.accentColor)
-                    }
+                    Toggle("Use Fullscreen API", isOn: $useFullscreenApi)
+                        .padding(.horizontal)
+                        .tint(.accentColor)
                     List {
                         ForEach(AdType.allCases, id: \.self) { adType in
                             NavigationLink(destination: adView(forAdType: adType)) {

--- a/swiftui/ChartboostMediationDemo/Ads/AdTypeSelectionView.swift
+++ b/swiftui/ChartboostMediationDemo/Ads/AdTypeSelectionView.swift
@@ -50,29 +50,29 @@ struct AdTypeSelectionView: View {
         }
     }
 
+    @ViewBuilder
     func adView(forAdType adType: AdType) -> some View {
-        let adView = GeometryReader { geometry in
-                ScrollView {
-                    Group {
-                        switch (adType, useFullscreenApi) {
-                        case (.banner, _):
-                            BannerAdView(placementName: "AllNetworkBanner")
-                        case (.interstitial, false):
-                            InterstitialAdView(placementName: "AllNetworkInterstitial")
-                        case (.interstitial, true):
-                            FullscreenAdView(placementName: "AllNetworkInterstitial")
-                        case (.rewarded, false):
-                            RewardedAdView(placementName: "AllNetworkRewarded")
-                        case (.rewarded, true):
-                            FullscreenAdView(placementName: "AllNetworkRewarded")
-                        }
+        GeometryReader { geometry in
+            ScrollView {
+                Group {
+                    switch (adType, useFullscreenApi) {
+                    case (.banner, _):
+                        BannerAdView(placementName: "AllNetworkBanner")
+                    case (.interstitial, false):
+                        InterstitialAdView(placementName: "AllNetworkInterstitial")
+                    case (.interstitial, true):
+                        FullscreenAdView(placementName: "AllNetworkInterstitial")
+                    case (.rewarded, false):
+                        RewardedAdView(placementName: "AllNetworkRewarded")
+                    case (.rewarded, true):
+                        FullscreenAdView(placementName: "AllNetworkRewarded")
                     }
-                    .frame(minHeight: geometry.size.height)
                 }
+                .frame(minHeight: geometry.size.height)
             }
-            .navigationTitle(adType.title)
-            .navigationBarTitleDisplayMode(.inline)
-            .edgesIgnoringSafeArea([.leading, .trailing, .bottom])
-        return adView
+        }
+        .navigationTitle(adType.title)
+        .navigationBarTitleDisplayMode(.inline)
+        .edgesIgnoringSafeArea([.leading, .trailing, .bottom])
     }
 }

--- a/swiftui/ChartboostMediationDemo/Ads/AdTypeSelectionView.swift
+++ b/swiftui/ChartboostMediationDemo/Ads/AdTypeSelectionView.swift
@@ -15,6 +15,7 @@ import SwiftUI
 /// A view that lists the different Chartboost Mediation SDK advertisement types. Selecting one will
 /// navigate to a view that can be used to load and show that type of advertisement.
 struct AdTypeSelectionView: View {
+    @State private var useFullscreenApi = true
     var body: some View {
         NavigationView {
             GeometryReader { geometry in
@@ -28,10 +29,14 @@ struct AdTypeSelectionView: View {
                             .padding(.vertical, 8)
                         Spacer()
                     }
-
+                    HStack {
+                        Toggle("Use Fullscreen API", isOn: $useFullscreenApi)
+                            .padding(.horizontal)
+                            .tint(.accentColor)
+                    }
                     List {
                         ForEach(AdType.allCases, id: \.self) { adType in
-                            NavigationLink(destination: adType.destination) {
+                            NavigationLink(destination: adView(forAdType: adType)) {
                                 HStack {
                                     adType.icon
                                     Text(adType.title)
@@ -46,27 +51,30 @@ struct AdTypeSelectionView: View {
             }
         }
     }
-}
 
-extension AdType {
-    @ViewBuilder var destination: some View {
-        GeometryReader { geometry in
-            ScrollView {
-                Group {
-                    switch self {
-                    case .banner:
-                        BannerAdView()
-                    case .interstitial:
-                        InterstitialAdView()
-                    case .rewarded:
-                        RewardedAdView()
+    func adView(forAdType adType: AdType) -> some View {
+        let adView = GeometryReader { geometry in
+                ScrollView {
+                    Group {
+                        switch (adType, useFullscreenApi) {
+                        case (.banner, _):
+                            BannerAdView()
+                        case (.interstitial, false):
+                            InterstitialAdView()
+                        case (.interstitial, true):
+                            FullscreenAdView()
+                        case (.rewarded, false):
+                            RewardedAdView()
+                        case (.rewarded, true):
+                            FullscreenAdView()
+                        }
                     }
+                    .frame(minHeight: geometry.size.height)
                 }
-                .frame(minHeight: geometry.size.height)
             }
-        }
-        .navigationTitle(title)
-        .navigationBarTitleDisplayMode(.inline)
-        .edgesIgnoringSafeArea([.leading, .trailing, .bottom])
+            .navigationTitle(adType.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .edgesIgnoringSafeArea([.leading, .trailing, .bottom])
+        return adView
     }
 }

--- a/swiftui/ChartboostMediationDemo/Ads/Banner/BannerAdView.swift
+++ b/swiftui/ChartboostMediationDemo/Ads/Banner/BannerAdView.swift
@@ -15,7 +15,7 @@ import SwiftUI
 
 /// A view that demonstrates the loading and showing of a Chartboost Mediation SDK banner advertisement.
 struct BannerAdView: View {
-    @StateObject private var controller = BannerAdController(placementName: "AllNetworkBanner")
+    @StateObject private var controller: BannerAdController
     @State private var isBusy = false
     @State private var failureMessage: String?
 
@@ -91,5 +91,9 @@ struct BannerAdView: View {
                 isBusy = false
             }
         }
+    }
+
+    init(placementName: String) {
+        self._controller = StateObject(wrappedValue: BannerAdController(placementName: placementName))
     }
 }

--- a/swiftui/ChartboostMediationDemo/Ads/Banner/BannerAdView.swift
+++ b/swiftui/ChartboostMediationDemo/Ads/Banner/BannerAdView.swift
@@ -86,7 +86,7 @@ struct BannerAdView: View {
                 isBusy = true
             case .failed(let message, let error):
                 isBusy = false
-                failureMessage = "\(message): \(error?.localizedDescription ?? "")"
+                failureMessage = message + (error.map { ": \($0.localizedDescription)" } ?? "")
             default:
                 isBusy = false
             }

--- a/swiftui/ChartboostMediationDemo/Ads/Banner/BannerAdView.swift
+++ b/swiftui/ChartboostMediationDemo/Ads/Banner/BannerAdView.swift
@@ -86,7 +86,7 @@ struct BannerAdView: View {
                 isBusy = true
             case .failed(let message, let error):
                 isBusy = false
-                failureMessage = "\(message): \(error.localizedDescription)"
+                failureMessage = "\(message): \(error?.localizedDescription ?? "")"
             default:
                 isBusy = false
             }

--- a/swiftui/ChartboostMediationDemo/Ads/Fullscreen/FullscreenAdController.swift
+++ b/swiftui/ChartboostMediationDemo/Ads/Fullscreen/FullscreenAdController.swift
@@ -39,7 +39,7 @@ class FullscreenAdController: NSObject, ObservableObject {
     /// - Parameter keywords: Optional keywords that can be associated with the advertisement placement.
     func load(keywords: HeliumKeywords? = nil) {
         // Attempt to load the ad only if it has not already been created and requested to load.
-        guard interstitialAd == nil else {
+        guard fullscreenAd == nil else {
             print("[Warning] interstitial advertisement has already been loaded")
             return
         }
@@ -111,7 +111,7 @@ class FullscreenAdController: NSObject, ObservableObject {
 // MARK: - Lifecycle Delegate
 
 /// Implementation of the Chartboost Mediation fullscreen ad delegate.
-extension InterstitialAdController: ChartboostMediationFullscreenAdDelegate {
+extension FullscreenAdController: ChartboostMediationFullscreenAdDelegate {
     func didRecordImpression(ad: ChartboostMediationFullscreenAd) {
         log(action: "Did record impression", placementName: placementName, error: nil)
     }
@@ -140,7 +140,7 @@ extension InterstitialAdController: ChartboostMediationFullscreenAdDelegate {
 
 // MARK: - Utility
 
-private extension InterstitialAdController {
+private extension FullscreenAdController {
     /// Log lifecycle information to the console for the interstitial advertisement.
     /// - Parameter action: What action is being logged
     /// - Parameter placementName: The placement name for the interstitial advertisement

--- a/swiftui/ChartboostMediationDemo/Ads/Fullscreen/FullscreenAdController.swift
+++ b/swiftui/ChartboostMediationDemo/Ads/Fullscreen/FullscreenAdController.swift
@@ -1,0 +1,156 @@
+// Copyright 2022-2023 Chartboost, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+//
+//  InterstitialAdController.swift
+//  ChartboostMediationDemo
+//
+//  Copyright © 2023 Chartboost. All rights reserved.
+//
+
+import UIKit
+import ChartboostMediationSDK
+
+/// A basic implementation of a controller for Chartboost Mediation interstitial ads.  It is capable of loading and showing a full screen interstitial ad
+/// for a single placement.  This controller is also its own `CHBHeliumInterstitialAdDelegate` so that it is in full control
+/// of the ad's lifecycle.
+class FullscreenAdController: NSObject, ObservableObject {
+    /// The entry point for the Chartboost Mediation SDK.
+    private let chartboostMediation = Helium.shared()
+
+    /// The placement that this controller is for.
+    private let placementName: String
+
+    /// An instance of the fullscreen ad that this class controls the lifecycle of when using the new API.
+    private var fullscreenAd: ChartboostMediationFullscreenAd?
+
+    /// A state for demo purposes only so that long activity processes can be communicated to a view.
+    @Published private(set) var activityState: ActivityState = .idle
+
+    /// Initializer for the view model.
+    /// - Parameter placementName: Placement to use.
+    init(placementName: String) {
+        self.placementName = placementName
+    }
+
+    /// Load the interstitial ad.
+    /// - Parameter keywords: Optional keywords that can be associated with the advertisement placement.
+    func load(keywords: HeliumKeywords? = nil) {
+        // Attempt to load the ad only if it has not already been created and requested to load.
+        guard interstitialAd == nil else {
+            print("[Warning] interstitial advertisement has already been loaded")
+            return
+        }
+
+        // Notify the demo UI
+        activityState = .running
+
+        // loadFullscreenAd expects keywords to be `[String : String]` instead of `HeliumKeywords?`.
+        let keywords = keywords?.dictionary ?? [:]
+        let request = ChartboostMediationAdLoadRequest(placement: placementName, keywords: keywords)
+        // Load the fullscreen ad, which will make a request to the network. Upon completion, a
+        // ChartboostMediationFullscreenAdLoadResult will be passed to the completion block.
+        chartboostMediation.loadFullscreenAd(with: request) { [weak self] result in
+            guard let self = self else { return }
+            if let ad = result.ad {
+                ad.delegate = self
+                self.fullscreenAd = ad
+
+                log(action: "load", placementName: placementName, error: result.error)
+                // Notify the demo UI
+                activityState = .idle
+            } else {
+                fullscreenAd = nil
+                self.log(action: "Load error", placementName: placementName, error: result.error)
+
+                // `.failed` requires a non-optional error type
+                let error = result.error ?? NSError(domain: "com.chartboost.mediation.demo", code: 0)
+                // Notify the demo UI
+                activityState = .failed(message: "Failed to load the interstitial advertisement.", error: error)
+            }
+        }
+    }
+
+    /// Show the interstitial ad if it has been loaded and is ready to show.
+    /// - Parameter viewController: The view controller to present the interstitial over.
+    func show(with viewController: UIViewController) {
+        // Attempt to show a fullscreen ad only if it has been loaded.
+        guard let fullscreenAd = fullscreenAd else {
+            print("[Error] cannot show a fullscreen advertisement that has not yet been loaded")
+            return
+        }
+
+        // ChartboostMediationFullscreenAd does not have an equivalent to HeliumInterstitialAd's readyToShow().
+
+        // Notify the demo UI.
+        activityState = .running
+
+        // Show the ad using the specified view controller.  Upon completion, instead of using a delegate
+        // method a ChartboostMediationAdShowResult will be passed to the completion block.
+        fullscreenAd.show(with: viewController, completion: { [weak self] result in
+            guard let self = self else { return }
+            self.log(action: "show", placementName: self.placementName, error: result.error)
+
+            // For simplicity, an ad that has failed to show will be destroyed.
+            if let error = result.error {
+                self.fullscreenAd = nil
+
+                // Notify the demo UI
+                self.activityState = .failed(message: "Failed to show the fullscreen advertisement.", error: error)
+            }
+            else {
+                // Notify the demo UI
+                self.activityState = .idle
+            }
+        })
+    }
+}
+
+// MARK: - Lifecycle Delegate
+
+/// Implementation of the Chartboost Mediation fullscreen ad delegate.
+extension InterstitialAdController: ChartboostMediationFullscreenAdDelegate {
+    func didRecordImpression(ad: ChartboostMediationFullscreenAd) {
+        log(action: "Did record impression", placementName: placementName, error: nil)
+    }
+
+    func didClick(ad: ChartboostMediationFullscreenAd) {
+        log(action: "Did click", placementName: placementName, error: nil)
+    }
+
+    func didReward(ad: ChartboostMediationFullscreenAd) {
+        log(action: "Did get reward", placementName: placementName, error: nil)
+    }
+
+    func didClose(ad: ChartboostMediationFullscreenAd, error: ChartboostMediationError?) {
+        if let error = error {
+            log(action: "Close error", placementName: placementName, error: error)
+        }
+        else {
+            log(action: "Did close", placementName: placementName, error: nil)
+        }
+    }
+
+    func didExpire(ad: ChartboostMediationFullscreenAd) {
+        log(action: "Did expire", placementName: placementName, error: nil)
+    }
+}
+
+// MARK: - Utility
+
+private extension InterstitialAdController {
+    /// Log lifecycle information to the console for the interstitial advertisement.
+    /// - Parameter action: What action is being logged
+    /// - Parameter placementName: The placement name for the interstitial advertisement
+    /// - Parameter error: An option error that occurred
+    func log(action: String, placementName: String, error: ChartboostMediationError?) {
+        if let error = error {
+            print("[Error] did \(action) interstitial advertisement for placement '\(placementName)': '\(error.debugDescription)' (name: \(error.chartboostMediationCode.name), code: \(error.code))")
+        }
+        else {
+            print("[Success] did \(action) interstitial advertisement for placement '\(placementName)'")
+        }
+    }
+}

--- a/swiftui/ChartboostMediationDemo/Ads/Fullscreen/FullscreenAdController.swift
+++ b/swiftui/ChartboostMediationDemo/Ads/Fullscreen/FullscreenAdController.swift
@@ -58,7 +58,7 @@ class FullscreenAdController: NSObject, ObservableObject {
                 ad.delegate = self
                 self.fullscreenAd = ad
 
-                log(action: "load", placementName: placementName, error: result.error)
+                log(action: "Load", placementName: placementName, error: result.error)
                 // Notify the demo UI
                 activityState = .idle
             } else {

--- a/swiftui/ChartboostMediationDemo/Ads/Fullscreen/FullscreenAdView.swift
+++ b/swiftui/ChartboostMediationDemo/Ads/Fullscreen/FullscreenAdView.swift
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file.
 
 //
-//  InterstitialAdView.swift
+//  FullscreenAdView.swift
 //  ChartboostMediationDemo
 //
 //  Copyright © 2023 Chartboost. All rights reserved.
@@ -13,18 +13,24 @@
 import UIKit
 import SwiftUI
 
-/// A view that demonstrates the loading and showing of a Chartboost Mediation SDK interstitial advertisement.
+/// A view that demonstrates the loading and showing of a Chartboost Mediation SDK fullscreen advertisement.
 struct FullscreenAdView: View {
     @StateObject private var controller: FullscreenAdController
     @State private var isBusy = false
     @State private var failureMessage: String?
+    private let adType: AdType
 
     var body: some View {
         VStack {
-            Image("Interstitial")
-                .padding(.vertical, 32)
+            if adType == .interstitial {
+                Image("Interstitial")
+                    .padding(.vertical, 32)
+            } else if adType == .rewarded {
+                Image("Rewarded")
+                    .padding(.vertical, 32)
+            }
 
-            Text("A full screen interstitial advertisement must first be loaded.")
+            Text("A full screen \(adType.title) advertisement must first be loaded.")
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 32)
 
@@ -83,7 +89,8 @@ struct FullscreenAdView: View {
         }
     }
 
-    init(placementName: String) {
+    init(adType: AdType, placementName: String) {
+        self.adType = adType
         self._controller = StateObject(wrappedValue: FullscreenAdController(placementName: placementName))
     }
 }

--- a/swiftui/ChartboostMediationDemo/Ads/Fullscreen/FullscreenAdView.swift
+++ b/swiftui/ChartboostMediationDemo/Ads/Fullscreen/FullscreenAdView.swift
@@ -15,7 +15,7 @@ import SwiftUI
 
 /// A view that demonstrates the loading and showing of a Chartboost Mediation SDK interstitial advertisement.
 struct FullscreenAdView: View {
-    @StateObject private var controller = FullscreenAdController(placementName: "AllNetworkInterstitial")
+    @StateObject private var controller: FullscreenAdController
     @State private var isBusy = false
     @State private var failureMessage: String?
 
@@ -81,5 +81,9 @@ struct FullscreenAdView: View {
                 isBusy = false
             }
         }
+    }
+
+    init(placementName: String) {
+        self._controller = StateObject(wrappedValue: FullscreenAdController(placementName: placementName))
     }
 }

--- a/swiftui/ChartboostMediationDemo/Ads/Fullscreen/FullscreenAdView.swift
+++ b/swiftui/ChartboostMediationDemo/Ads/Fullscreen/FullscreenAdView.swift
@@ -1,0 +1,85 @@
+// Copyright 2022-2023 Chartboost, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+//
+//  InterstitialAdView.swift
+//  ChartboostMediationDemo
+//
+//  Copyright © 2023 Chartboost. All rights reserved.
+//
+
+import UIKit
+import SwiftUI
+
+/// A view that demonstrates the loading and showing of a Chartboost Mediation SDK interstitial advertisement.
+struct FullscreenAdView: View {
+    @StateObject private var controller = FullscreenAdController(placementName: "AllNetworkInterstitial")
+    @State private var isBusy = false
+    @State private var failureMessage: String?
+
+    var body: some View {
+        VStack {
+            Image("Interstitial")
+                .padding(.vertical, 32)
+
+            Text("A full screen interstitial advertisement must first be loaded.")
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+
+            Button {
+                controller.load()
+            } label: {
+                Text("Load")
+                    .font(.title2)
+                    .foregroundColor(.white)
+                    .frame(height: 48)
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .padding(.horizontal, 32)
+
+            if let topViewController = UIApplication.topViewController {
+                Image("arrow-down")
+
+                Text("After it has been successfully loaded it can then be shown.")
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 32)
+
+                Button {
+                    controller.show(with: topViewController)
+                } label: {
+                    Text("Show")
+                        .font(.title2)
+                        .foregroundColor(.white)
+                        .frame(height: 48)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .padding(.horizontal, 32)
+            }
+
+            if let failureMessage = failureMessage {
+                Text(failureMessage)
+                    .foregroundColor(.red)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 32)
+            }
+
+            Spacer()
+        }
+        .busy($isBusy)
+        .onChange(of: controller.activityState) { newState in
+            switch newState {
+            case .running:
+                isBusy = true
+            case .failed(let message, let error):
+                isBusy = false
+                failureMessage = "\(message): \(error?.localizedDescription ?? "")"
+            default:
+                isBusy = false
+            }
+        }
+    }
+}

--- a/swiftui/ChartboostMediationDemo/Ads/Interstitial/InterstitialAdController.swift
+++ b/swiftui/ChartboostMediationDemo/Ads/Interstitial/InterstitialAdController.swift
@@ -23,8 +23,14 @@ class InterstitialAdController: NSObject, ObservableObject {
     /// The placement that is controller is for.
     private let placementName: String
 
-    /// An instance of the interstitial ad that this class controls the lifecycle of.
+    /// An instance of the interstitial ad that this class controls the lifecycle of when using the deprecated API.
     private var interstitialAd: HeliumInterstitialAd?
+
+    /// An instance of the fullscreen ad that this class controls the lifecycle of when using the new API.
+    private var fullscreenAd: ChartboostMediationFullscreenAd?
+
+    /// When `true`, controller will use the new fullscreen API instead of deprecated methods.
+    var fullscreenAPI: Bool = true
 
     /// A state for demo purposes only so that long activity processes can be communicated to a view.
     @Published private(set) var activityState: ActivityState = .idle
@@ -44,47 +50,105 @@ class InterstitialAdController: NSObject, ObservableObject {
             return
         }
 
-        // Create an interstitial ad from the Chartboost Mediation ad provider.
-        guard let interstitialAd = chartboostMediation.interstitialAdProvider(with: self, andPlacementName: placementName) else {
-            // It could fail if the placement name is invalid.
-            print("[Error] failed to create interstitial advertisement for placement '\(placementName)'")
-            return
-        }
-        self.interstitialAd = interstitialAd
-
         // Notify the demo UI
         activityState = .running
 
-        // Associate any provided keywords with the advertisement before it is loaded.
-        interstitialAd.keywords = keywords
+        if fullscreenAPI {
+            // loadFullscreenAd expects keywords to be `[String : String]` instead of `HeliumKeywords?`.
+            let keywords = keywords?.dictionary ?? [:]
+            let request = ChartboostMediationAdLoadRequest(placement: placementName, keywords: keywords)
+            // Load the fullscreen ad, which will make a request to the network. Upon completion, a
+            // ChartboostMediationFullscreenAdLoadResult will be passed to the completion block.
+            chartboostMediation.loadFullscreenAd(with: request) { [weak self] result in
+                guard let self = self else { return }
+                if let ad = result.ad {
+                    ad.delegate = self
+                    self.fullscreenAd = result.ad
 
-        // Load the interstitial ad, which will make a request to the network. Upon completion, the
-        // delegate method `heliumInterstitialAd(withPlacementName:didLoadWithError:)` will be called.
-        interstitialAd.load()
+                    log(action: "load", placementName: placementName, error: result.error)
+                    // Notify the demo UI
+                    activityState = .idle
+                } else {
+                    fullscreenAd = nil
+                    self.log(action: "Load error", placementName: placementName, error: result.error)
+
+                    // `.failed` requires a non-optional error type
+                    let error = result.error ?? NSError(domain: "com.chartboost.mediation.demo", code: 0)
+                    // Notify the demo UI
+                    activityState = .failed(message: "Failed to load the interstitial advertisement.", error: error)
+                }
+            }
+        } else {
+            // Create an interstitial ad using the deprecated Chartboost Mediation ad provider.
+            self.interstitialAd = chartboostMediation.interstitialAdProvider(with: self, andPlacementName: placementName)
+            guard let interstitialAd = interstitialAd else {
+                // Ad creation could have failed if the placement name is invalid.
+                print("[Error] failed to create interstitial advertisement for placement '\(placementName)'")
+                return
+            }
+            // Associate any provided keywords with the advertisement before it is loaded.
+            interstitialAd.keywords = keywords
+            // Load the interstitial ad, which will make a request to the network. Upon completion, the
+            // delegate method `heliumInterstitialAd(withPlacementName:didLoadWithError:)` will be called.
+            interstitialAd.load()
+        }
     }
 
     /// Show the interstitial ad if it has been loaded and is ready to show.
     /// - Parameter viewController: The view controller to present the interstitial over.
     func show(with viewController: UIViewController) {
-        // Attempt to show an ad only if it has been loaded.
-        guard let interstitialAd = interstitialAd else {
-            print("[Error] cannot show an interstitial advertisement that has not yet been loaded")
-            return
+
+        if fullscreenAPI {
+            // Attempt to show a fullscreen ad only if it has been loaded.
+            guard let fullscreenAd = fullscreenAd else {
+                print("[Error] cannot show a fullscreen advertisement that has not yet been loaded")
+                return
+            }
+
+            // ChartboostMediationFullscreenAd does not have an equivalent to HeliumInterstitialAd's readyToShow().
+
+            // Notify the demo UI.
+            activityState = .running
+
+            // Show the ad using the specified view controller.  Upon completion, instead of using a delegate
+            // method a ChartboostMediationAdShowResult will be passed to the completion block.
+            self.fullscreenAd?.show(with: viewController, completion: { [weak self] result in
+                guard let self = self else { return }
+                self.log(action: "show", placementName: self.placementName, error: result.error)
+
+                // For simplicity, an ad that has failed to show will be destroyed.
+                if let error = result.error {
+                    self.fullscreenAd = nil
+
+                    // Notify the demo UI
+                    self.activityState = .failed(message: "Failed to show the fullscreen advertisement.", error: error)
+                }
+                else {
+                    // Notify the demo UI
+                    self.activityState = .idle
+                }
+            })
+        } else {
+            // Attempt to show an interstitial ad only if it has been loaded.
+            guard let interstitialAd = interstitialAd else {
+                print("[Error] cannot show an interstitial advertisement that has not yet been loaded")
+                return
+            }
+
+            // Attempt to show an ad only if it is ready to show. It will not be ready yet if any of the
+            // network requests have not yet completed.
+            guard interstitialAd.readyToShow() else {
+                print("[Warning] not ready to show interstitial advertisement for placement '\(placementName)'")
+                return
+            }
+
+            // Notify the demo UI
+            activityState = .running
+
+            // Show the ad using the specified view controller.  Upon completion, the delegate meethod
+            // `heliumInterstitialAd(withPlacementName:didShowWithError:)` will be called.
+            interstitialAd.show(with: viewController)
         }
-
-        // Attempt to show an ad only if it is ready to show. It will not be ready yet if any of the
-        // network requests have not yet completed.
-        guard interstitialAd.readyToShow() else {
-            print("[Warning] not ready to show interstitial advertisement for placement '\(placementName)'")
-            return
-        }
-
-        // Notify the demo UI
-        activityState = .running
-
-        // Show the ad using the specified view controller.  Upon completion, the delegate meethod
-        // `heliumInterstitialAd(withPlacementName:didShowWithError:)` will be called.
-        interstitialAd.show(with: viewController)
     }
 }
 
@@ -160,5 +224,33 @@ private extension InterstitialAdController {
         else {
             print("[Success] did \(action) interstitial advertisement for placement '\(placementName)'")
         }
+    }
+}
+
+/// Implementation of the Chartboost Mediation fullscreen ad delegate.
+extension InterstitialAdController: ChartboostMediationFullscreenAdDelegate {
+    func didRecordImpression(ad: ChartboostMediationFullscreenAd) {
+        log(action: "Did record impression", placementName: placementName, error: nil)
+    }
+
+    func didClick(ad: ChartboostMediationFullscreenAd) {
+        log(action: "Did click", placementName: placementName, error: nil)
+    }
+
+    func didReward(ad: ChartboostMediationFullscreenAd) {
+        log(action: "Did get reward", placementName: placementName, error: nil)
+    }
+
+    func didClose(ad: ChartboostMediationFullscreenAd, error: ChartboostMediationError?) {
+        if let error = error {
+            log(action: "Close error", placementName: placementName, error: error)
+        }
+        else {
+            log(action: "Did close", placementName: placementName, error: nil)
+        }
+    }
+
+    func didExpire(ad: ChartboostMediationFullscreenAd) {
+        log(action: "Did expire", placementName: placementName, error: nil)
     }
 }

--- a/swiftui/ChartboostMediationDemo/Ads/Interstitial/InterstitialAdController.swift
+++ b/swiftui/ChartboostMediationDemo/Ads/Interstitial/InterstitialAdController.swift
@@ -63,7 +63,7 @@ class InterstitialAdController: NSObject, ObservableObject {
                 guard let self = self else { return }
                 if let ad = result.ad {
                     ad.delegate = self
-                    self.fullscreenAd = result.ad
+                    self.fullscreenAd = ad
 
                     log(action: "load", placementName: placementName, error: result.error)
                     // Notify the demo UI

--- a/swiftui/ChartboostMediationDemo/Ads/Interstitial/InterstitialAdController.swift
+++ b/swiftui/ChartboostMediationDemo/Ads/Interstitial/InterstitialAdController.swift
@@ -112,7 +112,7 @@ class InterstitialAdController: NSObject, ObservableObject {
 
             // Show the ad using the specified view controller.  Upon completion, instead of using a delegate
             // method a ChartboostMediationAdShowResult will be passed to the completion block.
-            self.fullscreenAd?.show(with: viewController, completion: { [weak self] result in
+            fullscreenAd.show(with: viewController, completion: { [weak self] result in
                 guard let self = self else { return }
                 self.log(action: "show", placementName: self.placementName, error: result.error)
 

--- a/swiftui/ChartboostMediationDemo/Ads/Interstitial/InterstitialAdView.swift
+++ b/swiftui/ChartboostMediationDemo/Ads/Interstitial/InterstitialAdView.swift
@@ -21,6 +21,10 @@ struct InterstitialAdView: View {
 
     var body: some View {
         VStack {
+            HStack {
+                Toggle("Use Fullscreen API", isOn: $controller.fullscreenAPI)
+                    .padding(.horizontal)
+            }
             Image("Interstitial")
                 .padding(.vertical, 32)
 

--- a/swiftui/ChartboostMediationDemo/Ads/Interstitial/InterstitialAdView.swift
+++ b/swiftui/ChartboostMediationDemo/Ads/Interstitial/InterstitialAdView.swift
@@ -21,10 +21,6 @@ struct InterstitialAdView: View {
 
     var body: some View {
         VStack {
-            HStack {
-                Toggle("Use Fullscreen API", isOn: $controller.fullscreenAPI)
-                    .padding(.horizontal)
-            }
             Image("Interstitial")
                 .padding(.vertical, 32)
 
@@ -80,7 +76,7 @@ struct InterstitialAdView: View {
                 isBusy = true
             case .failed(let message, let error):
                 isBusy = false
-                failureMessage = "\(message): \(error.localizedDescription)"
+                failureMessage = "\(message): \(error?.localizedDescription ?? "")"
             default:
                 isBusy = false
             }

--- a/swiftui/ChartboostMediationDemo/Ads/Interstitial/InterstitialAdView.swift
+++ b/swiftui/ChartboostMediationDemo/Ads/Interstitial/InterstitialAdView.swift
@@ -15,7 +15,7 @@ import SwiftUI
 
 /// A view that demonstrates the loading and showing of a Chartboost Mediation SDK interstitial advertisement.
 struct InterstitialAdView: View {
-    @StateObject private var controller = InterstitialAdController(placementName: "AllNetworkInterstitial")
+    @StateObject private var controller: InterstitialAdController
     @State private var isBusy = false
     @State private var failureMessage: String?
 
@@ -81,5 +81,9 @@ struct InterstitialAdView: View {
                 isBusy = false
             }
         }
+    }
+
+    init(placementName: String) {
+        self._controller = StateObject(wrappedValue: InterstitialAdController(placementName: placementName))
     }
 }

--- a/swiftui/ChartboostMediationDemo/Ads/Rewarded/RewardedAdView.swift
+++ b/swiftui/ChartboostMediationDemo/Ads/Rewarded/RewardedAdView.swift
@@ -15,7 +15,7 @@ import SwiftUI
 
 /// A view that demonstrates the loading and showing of a Chartboost Mediation SDK rewarded advertisement.
 struct RewardedAdView: View {
-    @StateObject private var controller = RewardedAdController(placementName: "AllNetworkRewarded")
+    @StateObject private var controller: RewardedAdController
     @State private var isBusy = false
     @State private var failureMessage: String?
 
@@ -81,5 +81,9 @@ struct RewardedAdView: View {
                 isBusy = false
             }
         }
+    }
+
+    init(placementName: String) {
+        self._controller = StateObject(wrappedValue: RewardedAdController(placementName: placementName))
     }
 }

--- a/swiftui/ChartboostMediationDemo/Ads/Rewarded/RewardedAdView.swift
+++ b/swiftui/ChartboostMediationDemo/Ads/Rewarded/RewardedAdView.swift
@@ -76,7 +76,7 @@ struct RewardedAdView: View {
                 isBusy = true
             case .failed(let message, let error):
                 isBusy = false
-                failureMessage = "\(message): \(error.localizedDescription)"
+                failureMessage = "\(message): \(error?.localizedDescription ?? "")"
             default:
                 isBusy = false
             }

--- a/swiftui/ChartboostMediationDemo/Utility/ActivityState.swift
+++ b/swiftui/ChartboostMediationDemo/Utility/ActivityState.swift
@@ -14,7 +14,7 @@
 enum ActivityState {
     case idle
     case running
-    case failed(message: String, error: Error)
+    case failed(message: String, error: Error?)
 }
 
 extension ActivityState: Equatable {


### PR DESCRIPTION
One way to add an example of the fullscreen ad API would have been to create another entry on the main screen of this app, after Interstitial and Rewarded. But on Android they have a toggle switch, so instead I added support for FullscreenAd on the the app's existing AdController. There are two ad variables, the load and show functions implement both versions, and the controller supports the delegate protocols for both the old and new API. 

I've made these changes just to the Interstitial Ad in the SwiftUI version of the demo app. Instead of applying every suggestion across four files I want to get this first one right and then I'll model the other three files (SwiftUI Rewarded, Swift Interstitial, Swift Rewarded) off of this one.

The difference between these two screenshots is that I used `.padding(.horizontal)` in the second one. I guess it looks ok like this... I wanted to at least see how it would look if the text label were next to the toggle switch like it is in the Android app, but I couldn't figure out how to do that in SwiftUI.
I'm open to other layout suggestions if you have ideas.

![without-padding](https://github.com/ChartBoost/chartboost-mediation-ios-sdk-demo/assets/8443666/5b7c225d-6995-4b4b-87b2-49f46e27a6b0)
![with-padding](https://github.com/ChartBoost/chartboost-mediation-ios-sdk-demo/assets/8443666/45220381-f843-4d76-b8c9-e83238c05e9f)
