### PR TITLE
HB-6489: undo the temporary CocoaPods fix

### DIFF
--- a/swift/Podfile
+++ b/swift/Podfile
@@ -24,17 +24,3 @@ target 'ChartboostMediationDemo' do
 #  pod 'ChartboostMediationAdapterYahoo'
 
 end
-
-# Temporary CocoaPods fix for Xcode 15. CocoaPods merged the fix already, but haven't
-# released it yet: https://github.com/CocoaPods/CocoaPods/pull/12009
-# See discussion here: https://github.com/CocoaPods/CocoaPods/issues/12012
-post_install do |installer|
-    installer.pods_project.targets.each do |target|
-        target.build_configurations.each do |config|
-            xcconfig_path = config.base_configuration_reference.real_path
-            xcconfig = File.read(xcconfig_path)
-            xcconfig_mod = xcconfig.gsub(/DT_TOOLCHAIN_DIR/, "TOOLCHAIN_DIR")
-            File.open(xcconfig_path, "w") { |file| file << xcconfig_mod }
-        end
-    end
-end

--- a/swiftui/Podfile
+++ b/swiftui/Podfile
@@ -24,17 +24,3 @@ target 'ChartboostMediationDemo' do
 #  pod 'ChartboostMediationAdapterYahoo'
 
 end
-
-# Temporary CocoaPods fix for Xcode 15. CocoaPods merged the fix already, but haven't
-# released it yet: https://github.com/CocoaPods/CocoaPods/pull/12009
-# See discussion here: https://github.com/CocoaPods/CocoaPods/issues/12012
-post_install do |installer|
-    installer.pods_project.targets.each do |target|
-        target.build_configurations.each do |config|
-            xcconfig_path = config.base_configuration_reference.real_path
-            xcconfig = File.read(xcconfig_path)
-            xcconfig_mod = xcconfig.gsub(/DT_TOOLCHAIN_DIR/, "TOOLCHAIN_DIR")
-            File.open(xcconfig_path, "w") { |file| file << xcconfig_mod }
-        end
-    end
-end


### PR DESCRIPTION
Undo PR #3.

It's no longer needed since the latest CocoaPods 1.13 has the fix.

Please review the Mediation reop PR as well: https://github.com/ChartBoost/ios-helium-sdk/pull/1421