### PR TITLE
HB-6944: update app ID

### DIFF
--- a/ChartboostMediationDemo/Demo_SwiftUI/AdTypeSelectionView.swift
+++ b/ChartboostMediationDemo/Demo_SwiftUI/AdTypeSelectionView.swift
@@ -56,15 +56,15 @@ struct AdTypeSelectionView: View {
                 Group {
                     switch (adType, useFullscreenApi) {
                     case (.banner, _):
-                        BannerAdView(placementName: "AllNetworkAdaptiveBanner")
+                        BannerAdView(placementName: "CBAdaptiveBanner")
                     case (.interstitial, false):
-                        InterstitialAdView(placementName: "AllNetworkInterstitial")
+                        InterstitialAdView(placementName: "CBInterstitial")
                     case (.interstitial, true):
-                        FullscreenAdView(adType: adType, placementName: "AllNetworkInterstitial")
+                        FullscreenAdView(adType: adType, placementName: "CBInterstitial")
                     case (.rewarded, false):
-                        RewardedAdView(placementName: "AllNetworkRewarded")
+                        RewardedAdView(placementName: "CBRewarded")
                     case (.rewarded, true):
-                        FullscreenAdView(adType: adType, placementName: "AllNetworkRewarded")
+                        FullscreenAdView(adType: adType, placementName: "CBRewarded")
                     }
                 }
                 .frame(minHeight: geometry.size.height)

--- a/ChartboostMediationDemo/Demo_UIKit/Banner/BannerAdViewController.swift
+++ b/ChartboostMediationDemo/Demo_UIKit/Banner/BannerAdViewController.swift
@@ -20,8 +20,8 @@ import UIKit
 ///
 class BannerAdViewController: UIViewController {
 
-    /// An instance of the `BannerAdController` that is configured to use the placement "AllNetworkAdaptiveBanner"
-    lazy var controller = BannerAdController(placementName: "AllNetworkAdaptiveBanner", activityDelegate: self)
+    /// An instance of the `BannerAdController` that is configured to use the placement "CBAdaptiveBanner"
+    lazy var controller = BannerAdController(placementName: "CBAdaptiveBanner", activityDelegate: self)
 
     /// The handler for when the load button is pushed.  Pushing it results in the banner ad being loaded.
     /// After it has successfully loaded, it can then be shown.

--- a/ChartboostMediationDemo/Demo_UIKit/Fullscreen/FullscreenAdViewController.swift
+++ b/ChartboostMediationDemo/Demo_UIKit/Fullscreen/FullscreenAdViewController.swift
@@ -25,7 +25,7 @@ class FullscreenAdViewController: UIViewController {
     /// An instance of the `FullscreenAdController` that is configured to use the placement "AllNetworkFullscreen"
     lazy var controller = FullscreenAdController(
         activityDelegate: self,
-        placementName: adType == .interstitial ? "AllNetworkInterstitial" : "AllNetworkRewarded"
+        placementName: adType == .interstitial ? "CBInterstitial" : "CBRewarded"
     )
 
     /// The handler for when the load button is pushed.  Pushing it results in the insterstitial ad being loaded.

--- a/ChartboostMediationDemo/Demo_UIKit/Interstitial/InterstitialAdViewController.swift
+++ b/ChartboostMediationDemo/Demo_UIKit/Interstitial/InterstitialAdViewController.swift
@@ -18,8 +18,8 @@ import UIKit
 ///
 class InterstitialAdViewController: UIViewController {
 
-    /// An instance of the `InterstitialAdController` that is configured to use the placement "AllNetworkInterstitial"
-    lazy var controller = InterstitialAdController(activityDelegate: self, placementName: "AllNetworkInterstitial")
+    /// An instance of the `InterstitialAdController` that is configured to use the placement "CBInterstitial"
+    lazy var controller = InterstitialAdController(activityDelegate: self, placementName: "CBInterstitial")
 
     /// The handler for when the load button is pushed.  Pushing it results in the insterstitial ad being loaded.
     /// After it has successfully loaded, it can then be shown.

--- a/ChartboostMediationDemo/Demo_UIKit/Rewarded/RewardedAdViewController.swift
+++ b/ChartboostMediationDemo/Demo_UIKit/Rewarded/RewardedAdViewController.swift
@@ -18,8 +18,8 @@ import UIKit
 ///
 class RewardedAdViewController: UIViewController {
 
-    /// An instance of the `RewardedAdController` that is configured to use the placement "AllNetworkRewarded"
-    lazy var controller = RewardedAdController(activityDelegate: self, placementName: "AllNetworkRewarded")
+    /// An instance of the `RewardedAdController` that is configured to use the placement "CBRewarded"
+    lazy var controller = RewardedAdController(activityDelegate: self, placementName: "CBRewarded")
 
     /// The handler for when the load button is pushed.  Pushing it results in the rewarded ad being loaded.
     /// After it has successfully loaded, it can then be shown.

--- a/ChartboostMediationDemo/Shared/Mediation SDK Controllers/ChartboostMediationController.swift
+++ b/ChartboostMediationDemo/Shared/Mediation SDK Controllers/ChartboostMediationController.swift
@@ -17,7 +17,7 @@ import ChartboostMediationSDK
 /// the `startHelium(completion:)` method is used.
 class ChartboostMediationController: NSObject, ObservableObject {
     /// The unique application identifier that is supplied by the Chartboost Mediation developer dashboard.
-    let appIdentifier: String = "5ce82fbffde3570afb4647bc"
+    let appIdentifier: String = "59c2b75ed7d75f0da04c452f"
 
     /// A static instance of this class so that it can be easily accessible throughout the application.
     static let instance: ChartboostMediationController = ChartboostMediationController()


### PR DESCRIPTION
Turns out Android and iOS cannot share app ID, because the fetched adapter config are different. Slack discussion: [link](https://chartboost.slack.com/archives/C031DUA8DNE/p1705021726316709?thread_ts=1705020724.778829&cid=C031DUA8DNE)
![image](https://github.com/ChartBoost/chartboost-mediation-ios-sdk-demo/assets/122156786/4b622863-2d1a-4599-a7ce-1b1116810358)

Use a dedicated iOS demo app ID `59c2b75ed7d75f0da04c452f` instead. 

App config JSON: https://config.mediation-sdk.chartboost.com/v1/sdk_init/59c2b75ed7d75f0da04c452f

```
{
  "app_id": "59c2b75ed7d75f0da04c452f",
  "credentials": {
    "admob": {
      "admob_app_id": "sdfasdkfjalsd padf"
    },
    "chartboost": {
      "app_id": "59c2b75ed7d75f0da04c452f",
      "app_signature": "dff3b4e9ed03e10b8d10e71cc101f0f485ec94ff"
    },
    "facebook": {
      "applicationid": "xxxxx"
    }
  },
  "banner_load_timeout": 15,
  "interstitial_load_timeout": 30,
  "rewarded_load_timeout": 30,
  "show_timeout": 5,
  "start_timeout": 20,
  "prebid_fetch_timeout": 5,
  "init_timeout": 1,
  "init_metrics_post_timeout": 10,
  "fullscreen_load_timeout": 30,
  "adapter_classes": [
    "ChartboostMediationAdapterAdColony.AdColonyAdapter",
    "ChartboostMediationAdapterAdMob.AdMobAdapter",
    "ChartboostMediationAdapterAmazonPublisherServices.AmazonPublisherServicesAdapter",
    "ChartboostMediationAdapterAppLovin.AppLovinAdapter",
    "ChartboostMediationAdapterChartboost.ChartboostAdapter",
    "ChartboostMediationAdapterDigitalTurbineExchange.DigitalTurbineExchangeAdapter",
    "ChartboostMediationAdapterGoogleBidding.GoogleBiddingAdapter",
    "ChartboostMediationAdapterHyprMX.HyprMXAdapter",
    "ChartboostMediationAdapterInMobi.InMobiAdapter",
    "ChartboostMediationAdapterIronSource.IronSourceAdapter",
    "ChartboostMediationAdapterMetaAudienceNetwork.MetaAudienceNetworkAdapter",
    "ChartboostMediationAdapterMintegral.MintegralAdapter",
    "ChartboostMediationAdapterPangle.PangleAdapter",
    "ChartboostMediationAdapterReference.ReferenceAdapter",
    "ChartboostMediationAdapterTapjoy.TapjoyAdapter",
    "ChartboostMediationAdapterUnityAds.UnityAdsAdapter",
    "ChartboostMediationAdapterVerve.VerveAdapter",
    "ChartboostMediationAdapterVungle.VungleAdapter",
    "ChartboostMediationAdapterYahoo.YahooAdapter",
    "ChartboostMediationAdapterMobileFuse.MobileFuseAdapter",
    "ChartboostMediationAdapterBidMachine.BidMachineAdapter"
  ],
  "placements": [
    {
      "auto_refresh_rate": 0,
      "chartboost_placement": "CBAdaptiveBanner",
      "format": "adaptive_banner"
    },
    {
      "auto_refresh_rate": 0,
      "chartboost_placement": "CBBanner",
      "format": "banner"
    },
    {
      "chartboost_placement": "CBInterstitial",
      "format": "interstitial"
    },
    {
      "chartboost_placement": "CBRewarded",
      "format": "rewarded"
    }
  ]
}
```