### PR TITLE
HB-5074: Mediation rebranding

### DIFF
--- a/ChartboostMediationDemo/Demo_ObjC/Banner/BannerAdController.h
+++ b/ChartboostMediationDemo/Demo_ObjC/Banner/BannerAdController.h
@@ -13,13 +13,13 @@ NS_ASSUME_NONNULL_BEGIN
 /// A basic implementation of a controller for Chartboost Mediation banner ads.  It is capable of loading and showing a banner ad
 /// for a single placement.  This controller is also its own `ChartboostMediationBannerViewDelegate` so that it is in full control
 /// of the ad's lifecycle.
-@interface BannerAdController : NSObject <ChartboostMediationBannerViewDelegate>
+@interface BannerAdController : NSObject <CBMBannerViewDelegate>
 
 /// The placement that is controller is for.
 @property (nonatomic, readonly) NSString *placementName;
 
 /// An instance of the banner ad that this class controls the lifecycle of.
-@property (nonatomic, strong, nullable, readonly) ChartboostMediationBannerView *bannerAd;
+@property (nonatomic, strong, nullable, readonly) CBMBannerView *bannerAd;
 
 /// Initialize the controller with a placement.
 /// - Parameter placementName: The name of the placement.

--- a/ChartboostMediationDemo/Demo_ObjC/Banner/BannerAdController.h
+++ b/ChartboostMediationDemo/Demo_ObjC/Banner/BannerAdController.h
@@ -11,7 +11,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// A basic implementation of a controller for Chartboost Mediation banner ads.  It is capable of loading and showing a banner ad
-/// for a single placement.  This controller is also its own `ChartboostMediationBannerViewDelegate` so that it is in full control
+/// for a single placement. This controller is also its own `CBMBannerViewDelegate` so that it is in full control
 /// of the ad's lifecycle.
 @interface BannerAdController : NSObject <CBMBannerViewDelegate>
 

--- a/ChartboostMediationDemo/Demo_ObjC/Banner/BannerAdController.m
+++ b/ChartboostMediationDemo/Demo_ObjC/Banner/BannerAdController.m
@@ -52,7 +52,7 @@
     __weak __typeof__(self) weakSelf = self;
     [self.bannerAd loadWith:request viewController:viewController completion:^(CBMBannerLoadResult * _Nonnull result) {
         BannerAdController *strongSelf = weakSelf;
-        ChartboostMediationError *error = result.error;
+        CBMError *error = result.error;
 
         [weakSelf logAction:@"load" placementName:strongSelf.placementName error:error];
 
@@ -77,7 +77,7 @@
     // This method can also be used to check other updated properties of `bannerView`.
 }
 
-- (void)logAction:(NSString *)action placementName:(NSString *)placementName error:(ChartboostMediationError *)error {
+- (void)logAction:(NSString *)action placementName:(NSString *)placementName error:(CBMError *)error {
     if (error) {
         NSLog(@"[Error] did %@ banner advertisement for placement '%@': '%@' (code: %li)", action, placementName, error.localizedDescription, error.code);
     }

--- a/ChartboostMediationDemo/Demo_ObjC/Banner/BannerAdController.m
+++ b/ChartboostMediationDemo/Demo_ObjC/Banner/BannerAdController.m
@@ -9,7 +9,7 @@
 @interface BannerAdController ()
 
 @property (nonatomic, weak, nullable) id<ActivityDelegate> activityDelegate;
-@property (nonatomic, strong, nullable) ChartboostMediationBannerView *bannerAd;
+@property (nonatomic, strong, nullable) CBMBannerView *bannerAd;
 
 @end
 
@@ -31,15 +31,15 @@
         return;
     }
 
-    self.bannerAd = [ChartboostMediationBannerView new];
+    self.bannerAd = [CBMBannerView new];
     self.bannerAd.delegate = self;
 
     // In this demo, we will load a 6x1 banner with the max width of the screen.
     // If you are instead loading a fixed size banner placement, you can do that with:
     // ChartboostMediationBannerSizeStandard, ChartboostMediationBannerSizeMedium, or
     // ChartboostMediationBannerSizeLeaderboard.
-    ChartboostMediationBannerSize *size = [ChartboostMediationBannerSize adaptive6x1WithWidth:width];
-    ChartboostMediationBannerLoadRequest *request = [[ChartboostMediationBannerLoadRequest alloc] initWithPlacement:self.placementName size:size];
+    CBMBannerSize *size = [CBMBannerSize adaptive6x1WithWidth:width];
+    CBMBannerLoadRequest *request = [[CBMBannerLoadRequest alloc] initWithPlacement:self.placementName size:size];
 
     // Notify the demo UI
     [self.activityDelegate activityDidStart];
@@ -50,7 +50,7 @@
     // Load the banner ad, which will make a request to the network. Upon completion, the
     // completion block will be called.
     __weak __typeof__(self) weakSelf = self;
-    [self.bannerAd loadWith:request viewController:viewController completion:^(ChartboostMediationBannerLoadResult * _Nonnull result) {
+    [self.bannerAd loadWith:request viewController:viewController completion:^(CBMBannerLoadResult * _Nonnull result) {
         BannerAdController *strongSelf = weakSelf;
         ChartboostMediationError *error = result.error;
 
@@ -71,7 +71,7 @@
     }];
 }
 
-- (void)willAppearWithBannerView:(ChartboostMediationBannerView *)bannerView {
+- (void)willAppearWithBannerView:(CBMBannerView *)bannerView {
     // Called when a new ad is about to appear inside of `bannerView`. This method can be used
     // to manually size `bannerView` if desired.
     // This method can also be used to check other updated properties of `bannerView`.

--- a/ChartboostMediationDemo/Demo_ObjC/Banner/BannerAdViewController.m
+++ b/ChartboostMediationDemo/Demo_ObjC/Banner/BannerAdViewController.m
@@ -35,7 +35,7 @@
 }
 
 - (IBAction)showButtonPushed:(id)sender {
-    ChartboostMediationBannerView *bannerAd = self.controller.bannerAd;
+    CBMBannerView *bannerAd = self.controller.bannerAd;
 
     // Attempt to show an ad only if it has been loaded.
     if (bannerAd == nil) {

--- a/ChartboostMediationDemo/Demo_ObjC/Fullscreen/FullscreenAdController.h
+++ b/ChartboostMediationDemo/Demo_ObjC/Fullscreen/FullscreenAdController.h
@@ -11,7 +11,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// A basic implementation of a controller for Chartboost Mediation fullscreen ads.  It is capable of loading and showing a full screen fullscreen ad
-/// for a single placement.  This controller is also its own `ChartboostMediationFullscreenAdDelegate` so that it is in full control
+/// for a single placement. This controller is also its own `CBMFullscreenAdDelegate` so that it is in full control
 /// of the ad's lifecycle.
 @interface FullscreenAdController : NSObject <CBMFullscreenAdDelegate>
 

--- a/ChartboostMediationDemo/Demo_ObjC/Fullscreen/FullscreenAdController.h
+++ b/ChartboostMediationDemo/Demo_ObjC/Fullscreen/FullscreenAdController.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// A basic implementation of a controller for Chartboost Mediation fullscreen ads.  It is capable of loading and showing a full screen fullscreen ad
 /// for a single placement.  This controller is also its own `ChartboostMediationFullscreenAdDelegate` so that it is in full control
 /// of the ad's lifecycle.
-@interface FullscreenAdController : NSObject <ChartboostMediationFullscreenAdDelegate>
+@interface FullscreenAdController : NSObject <CBMFullscreenAdDelegate>
 
 /// The placement that this controller is for.
 @property (nonatomic, readonly) NSString *placementName;
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Load the fullscreen ad.
 /// - Parameter keywords: Optional keywords that can be associated with the advertisement placement.
-- (void)loadWithKeywords:(HeliumKeywords * _Nullable)keywords;
+- (void)loadWithKeywords:(CBMKeywords * _Nullable)keywords;
 
 /// Show the fullscreen ad if it has been loaded and is ready to show.
 /// - Parameter viewController: The view controller to present the fullscreen over.

--- a/ChartboostMediationDemo/Demo_ObjC/Fullscreen/FullscreenAdController.h
+++ b/ChartboostMediationDemo/Demo_ObjC/Fullscreen/FullscreenAdController.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSString *placementName;
 
 /// An instance of the fullscreen ad that this class controls the lifecycle of when using the new API.
-@property (nonatomic, strong, nullable, readonly) id<ChartboostMediationFullscreenAd> fullscreenAd;
+@property (nonatomic, strong, nullable, readonly) id<CBMFullscreenAd> fullscreenAd;
 
 /// Initialize the controller with a placement.
 /// - Parameter placementName: The name of the placementt.

--- a/ChartboostMediationDemo/Demo_ObjC/Fullscreen/FullscreenAdController.m
+++ b/ChartboostMediationDemo/Demo_ObjC/Fullscreen/FullscreenAdController.m
@@ -8,7 +8,7 @@
 @interface FullscreenAdController ()
 
 @property (nonatomic, weak, nullable) id<ActivityDelegate> activityDelegate;
-@property (nonatomic, strong, nullable) id<ChartboostMediationFullscreenAd> fullscreenAd;
+@property (nonatomic, strong, nullable) id<CBMFullscreenAd> fullscreenAd;
 
 @end
 
@@ -39,7 +39,7 @@
 
     // Optional keywords that can be associated with the advertisement placement.
     NSDictionary<NSString *, NSString *>* keywordsDict = keywords.dictionary;
-    ChartboostMediationAdLoadRequest *request = [[ChartboostMediationAdLoadRequest alloc] initWithPlacement:self.placementName keywords:keywordsDict];
+    CBMAdLoadRequest *request = [[CBMAdLoadRequest alloc] initWithPlacement:self.placementName keywords:keywordsDict];
 
     // Load the fullscreen ad, which will make a request to the network. Upon completion, a
     // ChartboostMediationFullscreenAdLoadResult will be passed to the completion block.
@@ -49,7 +49,7 @@
         FullscreenAdController *strongSelf = weakSelf;
 
         [strongSelf logAction:@"load" placementName:strongSelf.placementName error:result.error];
-        id<ChartboostMediationFullscreenAd> ad = result.ad;
+        id<CBMFullscreenAd> ad = result.ad;
         if (ad) {
             ad.delegate = strongSelf;
             strongSelf.fullscreenAd = ad;
@@ -67,7 +67,7 @@
 }
 
 - (void)showWithViewController:(UIViewController *)viewController {
-    id<ChartboostMediationFullscreenAd> fullscreenAd = self.fullscreenAd;
+    id<CBMFullscreenAd> fullscreenAd = self.fullscreenAd;
 
     // Attempt to show a fullscreen ad only if it has been loaded.
     if (fullscreenAd == nil) {
@@ -78,7 +78,7 @@
     // Once you've loaded a ChartboostMediationFullscreenAd, it can be shown immediately.
 
     // Show the ad using the specified view controller.  Upon completion, a ChartboostMediationAdShowResult will be passed to the completion block.
-    [fullscreenAd showWith:viewController completion:^(ChartboostMediationAdShowResult * _Nonnull result) {
+    [fullscreenAd showWith:viewController completion:^(CBMAdShowResult * _Nonnull result) {
         [self logAction:@"show" placementName:self.placementName error:result.error];
 
         // For simplicity, an ad that has failed to show will be destroyed.
@@ -88,27 +88,27 @@
     }];
 }
 
-- (void)didRecordImpressionWithAd:(id<ChartboostMediationFullscreenAd>)ad {
+- (void)didRecordImpressionWithAd:(id<CBMFullscreenAd>)ad {
     [self logAction:@"record impression" placementName:self.placementName error:nil];
 }
 
-- (void)didClickWithAd:(id<ChartboostMediationFullscreenAd>)ad {
+- (void)didClickWithAd:(id<CBMFullscreenAd>)ad {
     [self logAction:@"click" placementName:self.placementName error:nil];
 }
 
-- (void)didRewardWithAd:(id<ChartboostMediationFullscreenAd>)ad {
+- (void)didRewardWithAd:(id<CBMFullscreenAd>)ad {
     [self logAction:@"get reward" placementName:self.placementName error:nil];
 }
 
-- (void)didCloseWithAd:(id<ChartboostMediationFullscreenAd>)ad error:(ChartboostMediationError *)error {
+- (void)didCloseWithAd:(id<CBMFullscreenAd>)ad error:(CBMError *)error {
     [self logAction:@"close" placementName:self.placementName error:error];
 }
 
-- (void)didExpireWithAd:(id<ChartboostMediationFullscreenAd>)ad {
+- (void)didExpireWithAd:(id<CBMFullscreenAd>)ad {
     [self logAction:@"expire" placementName:self.placementName error:nil];
 }
 
-- (void)logAction:(NSString *)action placementName:(NSString *)placementName error:(ChartboostMediationError *)error {
+- (void)logAction:(NSString *)action placementName:(NSString *)placementName error:(CBMError *)error {
     if (error) {
         NSLog(@"[Error] did %@ fullscreen advertisement for placement '%@': '%@' (code: %li)", action, placementName, error.localizedDescription, error.code);
     }

--- a/ChartboostMediationDemo/Demo_ObjC/Fullscreen/FullscreenAdController.m
+++ b/ChartboostMediationDemo/Demo_ObjC/Fullscreen/FullscreenAdController.m
@@ -27,7 +27,7 @@
     [self loadWithKeywords:nil];
 }
 
-- (void)loadWithKeywords:(HeliumKeywords * _Nullable)keywords {
+- (void)loadWithKeywords:(CBMKeywords * _Nullable)keywords {
     // Attempt to load the ad only if it has not already been created and requested to load.
     if (self.fullscreenAd) {
         NSLog(@"[Warning] fullscreen advertisement has already been loaded");
@@ -43,9 +43,9 @@
 
     // Load the fullscreen ad, which will make a request to the network. Upon completion, a
     // ChartboostMediationFullscreenAdLoadResult will be passed to the completion block.
-    Helium *chartboostMediation = Helium.sharedHelium;
+    ChartboostMediation *chartboostMediation = ChartboostMediation.shared;
     __weak __typeof__(self) weakSelf = self;
-    [chartboostMediation loadFullscreenAdWithRequest:request completion:^(ChartboostMediationFullscreenAdLoadResult * _Nonnull result) {
+    [chartboostMediation loadFullscreenAdWithRequest:request completion:^(CBMFullscreenAdLoadResult * _Nonnull result) {
         FullscreenAdController *strongSelf = weakSelf;
 
         [strongSelf logAction:@"load" placementName:strongSelf.placementName error:result.error];

--- a/ChartboostMediationDemo/Demo_ObjC/Initialization/ChartboostMediationController.h
+++ b/ChartboostMediationDemo/Demo_ObjC/Initialization/ChartboostMediationController.h
@@ -21,7 +21,7 @@ typedef void (^ChartboostMediationControllerCompletionBlock)(BOOL success, NSErr
 @property (nonatomic, class, readonly) ChartboostMediationController *sharedInstance;
 
 /// The shared instances of the Chartboost Mediation SDK.
-@property (nonatomic, class, readonly) Helium *chartboostMediation;
+@property (nonatomic, class, readonly) ChartboostMediation *chartboostMediation;
 
 /// A property that can be used to define and update the user's GDPR settings.
 /// For more information about GDPR, see: https://answers.chartboost.com/en-us/articles/115001489613

--- a/ChartboostMediationDemo/Demo_ObjC/Initialization/ChartboostMediationController.m
+++ b/ChartboostMediationDemo/Demo_ObjC/Initialization/ChartboostMediationController.m
@@ -26,8 +26,8 @@
     return sharedInstance;
 }
 
-+ (Helium *)chartboostMediation {
-    return Helium.sharedHelium;
++ (ChartboostMediation *)chartboostMediation {
+    return ChartboostMediation.shared;
 }
 
 - (void)startChartboostMediationWithCompletion:(ChartboostMediationControllerCompletionBlock)completionHandler {
@@ -44,7 +44,10 @@
     // instances of the NotificationCenter. In this demo, the method `didReceiveImpressionLevelTrackingData` receives
     // this data, parses it, and logs it to the console.
     NSNotificationCenter *notificationCenter = NSNotificationCenter.defaultCenter;
-    [notificationCenter addObserver:self selector:@selector(didReceiveImpressionLevelTrackingData:) name:NSNotification.heliumDidReceiveILRD object:nil];
+    [notificationCenter addObserver:self
+                           selector:@selector(didReceiveImpressionLevelTrackingData:)
+                               name:NSNotification.chartboostMediationDidReceiveILRD
+                             object:nil];
 
     // * Required *
     // Start the Chartboost Mediation SDK using the application identifier, application signature, and
@@ -77,14 +80,14 @@
 }
 
 - (void)didReceiveImpressionLevelTrackingData:(NSNotification *)notification {
-    HeliumImpressionData *ilrd = (HeliumImpressionData *)notification.object;
+    CBMImpressionData *ilrd = (CBMImpressionData *)notification.object;
     if (ilrd) {
         NSLog(@"[ILRD] received impression level tracking data");
         NSLog(@"[ILRD] %@", ilrd.jsonData);
     }
 }
 
-- (void)heliumDidStartWithError:(ChartboostMediationError *)error {
+- (void)heliumDidStartWithError:(CBMError *)error {
     if (error) {
         NSLog(@"[Error] failed to start Chartboost Mediation: '%@'", [error localizedDescription]);
         self.completionHandler(NO, error);

--- a/ChartboostMediationDemo/Demo_ObjC/Utility/UIViewController+ActivityDelegate.m
+++ b/ChartboostMediationDemo/Demo_ObjC/Utility/UIViewController+ActivityDelegate.m
@@ -45,7 +45,7 @@ static char kAssociatedObjectKey;
 }
 
 - (void)presentAlertWithMessage:(NSString *)message error:(NSError * _Nullable)error {
-    ChartboostMediationError *chartboostError = (ChartboostMediationError *)error;
+    CBMError *chartboostError = (CBMError *)error;
     NSString *alertMessage;
     if (chartboostError) {
         alertMessage = [NSString stringWithFormat:@"%@\n\n%@", message, chartboostError.localizedFailureReason];

--- a/ChartboostMediationDemo/Demo_SwiftUI/Banner.swift
+++ b/ChartboostMediationDemo/Demo_SwiftUI/Banner.swift
@@ -15,15 +15,15 @@ import SwiftUI
 
 /// A SwiftUI host view for a `ChartboostMediationBannerView`
 struct Banner: UIViewRepresentable {
-    typealias UIViewType = ChartboostMediationBannerView
+    typealias UIViewType = BannerView
 
-    let source: ChartboostMediationBannerView
+    let source: BannerView
 
-    func makeUIView(context: Context) -> ChartboostMediationBannerView {
+    func makeUIView(context: Context) -> BannerView {
         source
     }
 
-    func updateUIView(_ uiView: ChartboostMediationBannerView, context: Context) {
+    func updateUIView(_ uiView: BannerView, context: Context) {
 
     }
 }

--- a/ChartboostMediationDemo/Shared/Mediation SDK Controllers/BannerAdController.swift
+++ b/ChartboostMediationDemo/Shared/Mediation SDK Controllers/BannerAdController.swift
@@ -22,7 +22,7 @@ class BannerAdController: NSObject, ObservableObject {
     private let placementName: String
 
     /// An instance of the banner ad that this class controls the lifecycle of.
-    @Published private(set) var bannerAd: ChartboostMediationBannerView?
+    @Published private(set) var bannerAd: BannerView?
 
     /// A state for demo purposes only so that long activity processes can be communicated to a view.
     @Published private(set) var activityState: ActivityState = .idle
@@ -49,15 +49,15 @@ class BannerAdController: NSObject, ObservableObject {
             return
         }
 
-        bannerAd = ChartboostMediationBannerView()
+        bannerAd = BannerView()
         bannerAd?.delegate = self
 
         // In this demo, we will load a 6x1 banner with the max width of the screen.
         // If you are instead loading a fixed size banner placement, you can do that with:
         // ChartboostMediationBannerSize.standard, ChartboostMediationBannerSize.medium, or
         // ChartboostMediationBannerSize.leaderboard.
-        let size = ChartboostMediationBannerSize.adaptive6x1(width: width)
-        let request = ChartboostMediationBannerLoadRequest(
+        let size = BannerSize.adaptive6x1(width: width)
+        let request = BannerLoadRequest(
             placement: placementName,
             size: size
         )
@@ -97,9 +97,9 @@ class BannerAdController: NSObject, ObservableObject {
 // MARK: - Lifecycle Delegate
 
 /// Implementation of the Chartboost Mediation banner view delegate.
-extension BannerAdController: ChartboostMediationBannerViewDelegate {
+extension BannerAdController: BannerViewDelegate {
 
-    func willAppear(bannerView: ChartboostMediationBannerView) {
+    func willAppear(bannerView: BannerView) {
         // Called when a new ad is about to appear inside of `bannerView`. This method can be used
         // to manually size `bannerView` if desired:
         // if let size = bannerView.size?.size {

--- a/ChartboostMediationDemo/Shared/Mediation SDK Controllers/BannerAdController.swift
+++ b/ChartboostMediationDemo/Shared/Mediation SDK Controllers/BannerAdController.swift
@@ -14,7 +14,7 @@ import UIKit
 import ChartboostMediationSDK
 
 /// A basic implementation of a controller for Chartboost Mediation banner ads.  It is capable of loading and showing a banner ad
-/// for a single placement.  This controller is also its own `HeliumBannerAdDelegate` so that it is in full control
+/// for a single placement. This controller is also its own `ChartboostMediationBannerViewDelegate` so that it is in full control
 /// of the ad's lifecycle.
 class BannerAdController: NSObject, ObservableObject {
 

--- a/ChartboostMediationDemo/Shared/Mediation SDK Controllers/BannerAdController.swift
+++ b/ChartboostMediationDemo/Shared/Mediation SDK Controllers/BannerAdController.swift
@@ -14,7 +14,7 @@ import UIKit
 import ChartboostMediationSDK
 
 /// A basic implementation of a controller for Chartboost Mediation banner ads.  It is capable of loading and showing a banner ad
-/// for a single placement. This controller is also its own `ChartboostMediationBannerViewDelegate` so that it is in full control
+/// for a single placement. This controller is also its own `BannerViewDelegate` so that it is in full control
 /// of the ad's lifecycle.
 class BannerAdController: NSObject, ObservableObject {
 

--- a/ChartboostMediationDemo/Shared/Mediation SDK Controllers/ChartboostMediationController.swift
+++ b/ChartboostMediationDemo/Shared/Mediation SDK Controllers/ChartboostMediationController.swift
@@ -23,7 +23,7 @@ class ChartboostMediationController: NSObject, ObservableObject {
     static let instance: ChartboostMediationController = ChartboostMediationController()
 
     /// The shared instances of the Chartboost Mediation SDK.
-    let chartboostMediation = Helium.shared()
+    let chartboostMediation = ChartboostMediation.shared()
 
     /// A convenient structure that defines a user's GDPR privacy settings.
     /// For more information about GDPR, see: https://answers.chartboost.com/en-us/articles/115001489613
@@ -86,14 +86,19 @@ class ChartboostMediationController: NSObject, ObservableObject {
         // * Optional *
         // Enable test mode to make test ads available.
         // Do not enable test mode in production builds.
-        Helium.isTestModeEnabled = true
+        ChartboostMediation.isTestModeEnabled = true
 
         // * Optional *
         // Register for impression level revenue data notifications. The Chartboost Mediation SDK publishes this data on the `default`
         // instances of the NotificationCenter. In this demo, the method `didReceiveImpressionLevelTrackingData` receives
         // this data, parses it, and logs it to the console.
         let notificationCenter: NotificationCenter = .default
-        notificationCenter.addObserver(self, selector: #selector(didReceiveImpressionLevelTrackingData(notification:)), name: .heliumDidReceiveILRD, object: nil)
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(didReceiveImpressionLevelTrackingData(notification:)),
+            name: .chartboostMediationDidReceiveILRD,
+            object: nil
+        )
 
         // * Optional *
         // Provide a configuration data object before initializing the SDK.
@@ -132,7 +137,7 @@ class ChartboostMediationController: NSObject, ObservableObject {
     }
 
     @objc private func didReceiveImpressionLevelTrackingData(notification: Notification) {
-        guard let ilrd = notification.object as? HeliumImpressionData else {
+        guard let ilrd = notification.object as? ImpressionData else {
             return
         }
         print("[ILRD] received impression level tracking data")

--- a/ChartboostMediationDemo/Shared/Mediation SDK Controllers/FullscreenAdController.swift
+++ b/ChartboostMediationDemo/Shared/Mediation SDK Controllers/FullscreenAdController.swift
@@ -14,7 +14,7 @@ import UIKit
 import ChartboostMediationSDK
 
 /// A basic implementation of a controller for Chartboost Mediation fullscreen ads.  It is capable of loading and showing a full screen fullscreen ad
-/// for a single placement.  This controller is also its own `CHBHeliumFullscreenAdDelegate` so that it is in full control
+/// for a single placement. This controller is also its own `FullscreenAdDelegate` so that it is in full control
 /// of the ad's lifecycle.
 class FullscreenAdController: NSObject, ObservableObject {
     /// The entry point for the Chartboost Mediation SDK.

--- a/ChartboostMediationDemo/Shared/Mediation SDK Controllers/FullscreenAdController.swift
+++ b/ChartboostMediationDemo/Shared/Mediation SDK Controllers/FullscreenAdController.swift
@@ -24,7 +24,7 @@ class FullscreenAdController: NSObject, ObservableObject {
     private let placementName: String
 
     /// An instance of the fullscreen ad that this class controls the lifecycle of when using the new API.
-    private var fullscreenAd: ChartboostMediationFullscreenAd?
+    private var fullscreenAd: FullscreenAd?
 
     /// A state for demo purposes only so that long activity processes can be communicated to a view.
     @Published private(set) var activityState: ActivityState = .idle
@@ -55,7 +55,7 @@ class FullscreenAdController: NSObject, ObservableObject {
 
         // loadFullscreenAd expects keywords to be `[String : String]` instead of `HeliumKeywords?`.
         let keywords = keywords?.dictionary ?? [:]
-        let request = ChartboostMediationAdLoadRequest(placement: placementName, keywords: keywords)
+        let request = AdLoadRequest(placement: placementName, keywords: keywords)
         // Load the fullscreen ad, which will make a request to the network. Upon completion, a
         // ChartboostMediationFullscreenAdLoadResult will be passed to the completion block.
         chartboostMediation.loadFullscreenAd(with: request) { [weak self] result in
@@ -121,23 +121,23 @@ class FullscreenAdController: NSObject, ObservableObject {
 
 /// Implementation of the Chartboost Mediation fullscreen ad delegate.
 extension FullscreenAdController: FullscreenAdDelegate {
-    func didRecordImpression(ad: ChartboostMediationFullscreenAd) {
+    func didRecordImpression(ad: FullscreenAd) {
         log(action: "record impression", placementName: placementName, error: nil)
     }
 
-    func didClick(ad: ChartboostMediationFullscreenAd) {
+    func didClick(ad: FullscreenAd) {
         log(action: "click", placementName: placementName, error: nil)
     }
 
-    func didReward(ad: ChartboostMediationFullscreenAd) {
+    func didReward(ad: FullscreenAd) {
         log(action: "get reward", placementName: placementName, error: nil)
     }
 
-    func didClose(ad: ChartboostMediationFullscreenAd, error: ChartboostMediationError?) {
+    func didClose(ad: FullscreenAd, error: ChartboostMediationError?) {
         log(action: "close", placementName: placementName, error: error)
     }
 
-    func didExpire(ad: ChartboostMediationFullscreenAd) {
+    func didExpire(ad: FullscreenAd) {
         log(action: "expire", placementName: placementName, error: nil)
     }
 }

--- a/ChartboostMediationDemo/Shared/Mediation SDK Controllers/FullscreenAdController.swift
+++ b/ChartboostMediationDemo/Shared/Mediation SDK Controllers/FullscreenAdController.swift
@@ -120,7 +120,7 @@ class FullscreenAdController: NSObject, ObservableObject {
 // MARK: - Lifecycle Delegate
 
 /// Implementation of the Chartboost Mediation fullscreen ad delegate.
-extension FullscreenAdController: ChartboostMediationFullscreenAdDelegate {
+extension FullscreenAdController: FullscreenAdDelegate {
     func didRecordImpression(ad: ChartboostMediationFullscreenAd) {
         log(action: "record impression", placementName: placementName, error: nil)
     }

--- a/ChartboostMediationDemo/Shared/Mediation SDK Controllers/FullscreenAdController.swift
+++ b/ChartboostMediationDemo/Shared/Mediation SDK Controllers/FullscreenAdController.swift
@@ -18,7 +18,7 @@ import ChartboostMediationSDK
 /// of the ad's lifecycle.
 class FullscreenAdController: NSObject, ObservableObject {
     /// The entry point for the Chartboost Mediation SDK.
-    private let chartboostMediation = Helium.shared()
+    private let chartboostMediation = ChartboostMediation.shared()
 
     /// The placement that this controller is for.
     private let placementName: String
@@ -42,7 +42,7 @@ class FullscreenAdController: NSObject, ObservableObject {
 
     /// Load the fullscreen ad.
     /// - Parameter keywords: Optional keywords that can be associated with the advertisement placement.
-    func load(keywords: HeliumKeywords? = nil) {
+    func load(keywords: Keywords? = nil) {
         // Attempt to load the ad only if it has not already been created and requested to load.
         guard fullscreenAd == nil else {
             print("[Warning] fullscreen advertisement has already been loaded")

--- a/Podfile
+++ b/Podfile
@@ -10,7 +10,7 @@ abstract_target 'Demo' do
 #  pod 'ChartboostMediationAdapterAdMob'
 #  pod 'ChartboostMediationAdapterAppLovin'
 #  pod 'ChartboostMediationAdapterAmazonPublisherServices'
-  pod 'ChartboostMediationAdapterChartboost'
+#  pod 'ChartboostMediationAdapterChartboost' # TODO: uncomment this for Mediation 5 when it's ready
 #  pod 'ChartboostMediationAdapterDigitalTurbineExchange'
 #  pod 'ChartboostMediationAdapterGoogleBidding'
 #  pod 'ChartboostMediationAdapterInMobi'


### PR DESCRIPTION
1. Drop the "Helium" word
2. Remove the "ChartboostMediation" prefix for some Swift definitions, or replace it with "CBM" in Objective C

Associated Mediation PR: https://github.com/ChartBoost/ios-helium-sdk/pull/1707